### PR TITLE
Add nullcheck to SteamAudioSource component

### DIFF
--- a/unity/src/project/SteamAudioUnity/Assets/SteamAudio/SteamAudioSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/SteamAudio/SteamAudioSource.cs
@@ -74,6 +74,10 @@ namespace SteamAudio
             var environment = managerData.gameEngineState.Environment().GetEnvironment();
 
             var listener = GameObject.FindObjectOfType<AudioListener>();
+            if (!listener) {
+                return;
+            }
+
             var listenerPosition = Common.ConvertVector(listener.transform.position);
             var listenerAhead = Common.ConvertVector(listener.transform.forward);
             var listenerUp = Common.ConvertVector(listener.transform.up);


### PR DESCRIPTION
- If there is no AudioListener, Unity will be spamming the console so there is no need for further console spam from Steam Audio
- This is a common situation with VR interaction toolkits like VRTK where the Listener is missing the first frame