### PR TITLE
Fixed Unity exception on call to `iplCreateContext`.

### DIFF
--- a/unity/src/project/SteamAudioUnity/Assets/SteamAudio/GameEngineState.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/SteamAudio/GameEngineState.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using AOT;
 using UnityEngine;
 
 namespace SteamAudio
@@ -239,6 +240,7 @@ namespace SteamAudio
             }
         }
 
+        [MonoPInvokeCallback(typeof(LogCallback))]
         static void LogMessage(string message)
         {
             Debug.Log(message);


### PR DESCRIPTION
Exception: NotSupportedException: To marshal a managed method, please add an attribute named 'MonoPInvokeCallback' to the method definition.

Cause: The call to `iplCreateContext` passes static method `LogCallback` which hasn't been annotated with the `MonoPInvokeCallback` attribute.

Fix: Annotate `LogCallback` with the `MonoPInvokeCallback` attribute. Tested with Unity 2018.3.14f1 and IL2CPP, on Windows 64-bit, in two live games.