### PR TITLE
Correct mistake in docs about the supported ambisonics order in Unity

### DIFF
--- a/unity/doc/guide.rst
+++ b/unity/doc/guide.rst
@@ -35,7 +35,7 @@ In Unity, you configure individual audio clips as Ambisonic, instead of audio so
 
 .. note::
     
-    Unity supports up to 2nd order Ambisonic clips. They must use AmbiX (ACN/SN3D) layout. For more information, refer to the `Unity documentation <https://docs.unity3d.com/Manual/AmbisonicAudio.html>`_.
+    Unity supports 1st order Ambisonic clips, only. They must use AmbiX (ACN/SN3D) layout. For more information, refer to the `Unity documentation <https://docs.unity3d.com/Manual/AmbisonicAudio.html>`_.
 
 You can control how an Ambisonic audio clip is spatialized using the :doc:`Steam Audio Ambisonic Source <ambisonic-source>` component.
 


### PR DESCRIPTION
Steam audio docs falsely state that Unity supports 2nd order ambisonics clips. While that would be great indeed, it doesn't appear to be the case (tested in 2020.3 and 2021.1 on macOS, playback fails within Unity's fmod library due to the channel count being above 8). Also, the Unity docs linked to in the guide clearly state the opposite:
```
There is no support for second order ambisonics.
```  

This PR fixes this mistake.