### PR TITLE
Add bool for applying HRTF to direct signal in Unity

### DIFF
--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioSourceInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioSourceInspector.cs
@@ -49,6 +49,7 @@ namespace SteamAudio
         SerializedProperty mFindAlternatePaths;
         SerializedProperty mApplyHRTFToPathing;
         SerializedProperty mPathingMixLevel;
+        SerializedProperty mApplyHRTFToDirect;
 
         Texture2D mDirectivityPreview = null;
         float[] mDirectivitySamples = null;
@@ -81,6 +82,7 @@ namespace SteamAudio
             mTransmissionLow = serializedObject.FindProperty("transmissionLow");
             mTransmissionMid = serializedObject.FindProperty("transmissionMid");
             mTransmissionHigh = serializedObject.FindProperty("transmissionHigh");
+            mApplyHRTFToDirect = serializedObject.FindProperty("applyHRTFToDirect");
             mDirectMixLevel = serializedObject.FindProperty("directMixLevel");
             mReflections = serializedObject.FindProperty("reflections");
             mReflectionsType = serializedObject.FindProperty("reflectionsType");
@@ -200,6 +202,7 @@ namespace SteamAudio
 
             if (audioEngineIsUnity)
             {
+                EditorGUILayout.PropertyField(mApplyHRTFToDirect);
                 EditorGUILayout.PropertyField(mDirectMixLevel);
             }
 

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioSource.cs
@@ -104,7 +104,8 @@ namespace SteamAudio
         [Range(0.0f, 1.0f)]
         public float transmissionHigh = 1.0f;
 
-        [Header("Direct Mix Settings")]
+        [Header("Direct Settings")]
+        public bool applyHRTFToDirect = true;
         [Range(0.0f, 1.0f)]
         public float directMixLevel = 1.0f;
 

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/UnityAudioEngineSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/UnityAudioEngineSource.cs
@@ -47,6 +47,7 @@ namespace SteamAudio
             mAudioSource.SetSpatializerFloat(index++, source.transmissionLow);
             mAudioSource.SetSpatializerFloat(index++, source.transmissionMid);
             mAudioSource.SetSpatializerFloat(index++, source.transmissionHigh);
+            mAudioSource.SetSpatializerFloat(index++, (source.applyHRTFToDirect) ? 1.0f : 0.0f);
             mAudioSource.SetSpatializerFloat(index++, source.directMixLevel);
             mAudioSource.SetSpatializerFloat(index++, (source.applyHRTFToReflections) ? 1.0f : 0.0f);
             mAudioSource.SetSpatializerFloat(index++, source.reflectionsMixLevel);


### PR DESCRIPTION
There used to be an option called "directBinaural" during the 2.0 version cycle, which got removed from Steam Audio v4.0 without any explanation. Without this option, Steam Audio would always apply HRTFs to the direct signal. This means you cannot use it in projects where the end-user could be listening without headphones (for instance, laptop speakers, surround setups, custom installation setups).

This commit adds support for disabling HRTFs on the direct signal in the Steam Audio Unity spatializer plugin. It can be controlled with a bool on the SteamAudioSource component and the option defaults to true, which makes it backwards compatible to v4.0.0

The changes were tested on Windows x64 and macOS ARM (via Rosetta).