### PR TITLE
Fix compatibility with Enter Play Mode options

### DIFF
--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioManager.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioManager.cs
@@ -383,6 +383,14 @@ namespace SteamAudio
                 {
                     mAudioEngineState.Initialize(mContext.Get(), mHRTFs[0].Get(), simulationSettings);
                 }
+
+#if UNITY_EDITOR
+                // If the developer has disabled scene reload, SceneManager.sceneLoaded won't fire during initial load
+                if (EditorSettings.enterPlayModeOptions.HasFlag(EnterPlayModeOptions.DisableSceneReload))
+                {
+                    OnSceneLoaded(SceneManager.GetActiveScene(), LoadSceneMode.Single);
+                }
+#endif
             }
         }
 
@@ -613,6 +621,9 @@ namespace SteamAudio
                     sSingleton.mHRTFs[i] = null;
                 }
             }
+
+            SceneManager.sceneLoaded -= sSingleton.OnSceneLoaded;
+            SceneManager.sceneUnloaded -= sSingleton.OnSceneUnloaded;
 
             sSingleton.mContext.Release();
             sSingleton.mContext = null;


### PR DESCRIPTION
Unity allows developers to speed up iteration time in Editor with Play Mode options (https://docs.unity3d.com/Manual/ConfigurableEnterPlayMode.html). 
However, currently using any of the two options doesn't work with Steam Audio. This PR addreses this.

Disabling Scene Reload causes the SceneManager.sceneLoaded event to not be fired on initialization. When this option is enabled, OnSceneLoaded has to be called manually. This should address #219 and potentially #225.

Disabling Domain Reload leaves the SceneManager event handlers still subscribed even when SteamAudioManager is destroyed, which can be fixed by explicitly unsubscribing during shutdown.
Tested on Unity 2021.3