### PR TITLE
Fix the Baker so it looks for SteamAudioStaticMesh not only at the root of a scene.

### DIFF
--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/Baker.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/Baker.cs
@@ -68,7 +68,7 @@ namespace SteamAudio
             var rootObjects = SceneManager.GetActiveScene().GetRootGameObjects();
             foreach (var rootObject in rootObjects)
             {
-                staticMeshComponent = rootObject.GetComponent<SteamAudioStaticMesh>();
+                staticMeshComponent = rootObject.GetComponentInChildren<SteamAudioStaticMesh>();
                 if (staticMeshComponent)
                     break;
             }


### PR DESCRIPTION
If the "SteamAudioStaticMesh" is moved inside another game object. the Baker will believe that the object doesn't exist, whereas this scenario is perfectly supported in the SteamAudioManager (example in GetDataAsset(UnityEngine.SceneManagement.Scene scene)) or the SteamAudioProbeBatch.