### PR TITLE
[Unity] Allow Steam Audio to load but not run on unsupported platform or when STEAMAUDIO_ENABLED define symbol is not present.

### DIFF
--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioBakedListenerInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioBakedListenerInspector.cs
@@ -11,6 +11,7 @@ namespace SteamAudio
     [CustomEditor(typeof(SteamAudioBakedListener))]
     public class SteamAudioBakedListenerInspector : Editor
     {
+#if STEAMAUDIO_ENABLED
         SerializedProperty mInfluenceRadius;
         SerializedProperty mUseAllProbeBatches;
         SerializedProperty mProbeBatches;
@@ -75,5 +76,11 @@ namespace SteamAudio
 
             serializedObject.ApplyModifiedProperties();
         }
+#else
+        public override void OnInspectorGUI()
+        {
+            EditorGUILayout.HelpBox("Steam Audio is not supported for the target platform or STEAMAUDIO_ENABLED define symbol is missing.", MessageType.Warning);
+        }
+#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioBakedSourceInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioBakedSourceInspector.cs
@@ -11,6 +11,7 @@ namespace SteamAudio
     [CustomEditor(typeof(SteamAudioBakedSource))]
     public class SteamAudioBakedSourceInspector : Editor
     {
+#if STEAMAUDIO_ENABLED
         SerializedProperty mInfluenceRadius;
         SerializedProperty mUseAllProbeBatches;
         SerializedProperty mProbeBatches;
@@ -75,5 +76,11 @@ namespace SteamAudio
 
             serializedObject.ApplyModifiedProperties();
         }
+#else
+        public override void OnInspectorGUI()
+        {
+            EditorGUILayout.HelpBox("Steam Audio is not supported for the target platform or STEAMAUDIO_ENABLED define symbol is missing.", MessageType.Warning);
+        }
+#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioDynamicObjectInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioDynamicObjectInspector.cs
@@ -12,6 +12,7 @@ namespace SteamAudio
     [CustomEditor(typeof(SteamAudioDynamicObject))]
     public class SteamAudioDynamicObjectInspector : Editor
     {
+ #if STEAMAUDIO_ENABLED
         SerializedProperty mAsset;
 
         private void OnEnable()
@@ -53,5 +54,11 @@ namespace SteamAudio
 
             serializedObject.ApplyModifiedProperties();
         }
+#else
+        public override void OnInspectorGUI()
+        {
+            EditorGUILayout.HelpBox("Steam Audio is not supported for the target platform or STEAMAUDIO_ENABLED define symbol is missing.", MessageType.Warning);
+        }
+#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioGeometryInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioGeometryInspector.cs
@@ -12,6 +12,7 @@ namespace SteamAudio
     [CanEditMultipleObjects]
     public class SteamAudioGeometryInspector : Editor
     {
+#if STEAMAUDIO_ENABLED
         SerializedProperty mMaterial;
         SerializedProperty mExportAllChildren;
         SerializedProperty mTerrainSimplificationLevel;
@@ -48,5 +49,11 @@ namespace SteamAudio
 
             serializedObject.ApplyModifiedProperties();
         }
+#else
+        public override void OnInspectorGUI()
+        {
+            EditorGUILayout.HelpBox("Steam Audio is not supported for the target platform or STEAMAUDIO_ENABLED define symbol is missing.", MessageType.Warning);
+        }
+#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioListenerInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioListenerInspector.cs
@@ -11,6 +11,7 @@ namespace SteamAudio
     [CustomEditor(typeof(SteamAudioListener))]
     public class SteamAudioListenerInspector : Editor
     {
+#if STEAMAUDIO_ENABLED
         SerializedProperty mCurrentBakedListener;
         SerializedProperty mApplyReverb;
         SerializedProperty mReverbType;
@@ -86,5 +87,11 @@ namespace SteamAudio
 
             serializedObject.ApplyModifiedProperties();
         }
+#else
+        public override void OnInspectorGUI()
+        {
+            EditorGUILayout.HelpBox("Steam Audio is not supported for the target platform or STEAMAUDIO_ENABLED define symbol is missing.", MessageType.Warning);
+        }
+#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioManagerInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioManagerInspector.cs
@@ -11,6 +11,7 @@ namespace SteamAudio
     [CanEditMultipleObjects]
     public class SteamAudioManagerInspector : Editor
     {
+#if STEAMAUDIO_ENABLED
         SerializedProperty mCurrentHRTF;
 
         private void OnEnable()
@@ -35,5 +36,11 @@ namespace SteamAudio
 
             serializedObject.ApplyModifiedProperties();
         }
+#else
+        public override void OnInspectorGUI()
+        {
+            EditorGUILayout.HelpBox("Steam Audio is not supported for the target platform or STEAMAUDIO_ENABLED define symbol is missing.", MessageType.Warning);
+        }
+#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioProbeBatchInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioProbeBatchInspector.cs
@@ -13,6 +13,7 @@ namespace SteamAudio
     [CustomEditor(typeof(SteamAudioProbeBatch))]
     public class SteamAudioProbeBatchInspector : Editor
     {
+#if STEAMAUDIO_ENABLED
         SerializedProperty mPlacementStrategy;
         SerializedProperty mHorizontalSpacing;
         SerializedProperty mHeightAboveFloor;
@@ -121,5 +122,11 @@ namespace SteamAudio
 
             serializedObject.ApplyModifiedProperties();
         }
+#else
+        public override void OnInspectorGUI()
+        {
+            EditorGUILayout.HelpBox("Steam Audio is not supported for the target platform or STEAMAUDIO_ENABLED define symbol is missing.", MessageType.Warning);
+        }
+#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioStaticMeshInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioStaticMeshInspector.cs
@@ -11,6 +11,7 @@ namespace SteamAudio
     [CustomEditor(typeof(SteamAudioStaticMesh))]
     public class SteamAudioStaticMeshInspector : Editor
     {
+#if STEAMAUDIO_ENABLED
         SerializedProperty mAsset;
         SerializedProperty mSceneNameWhenExported;
 
@@ -53,5 +54,11 @@ namespace SteamAudio
 
             serializedObject.ApplyModifiedProperties();
         }
+#else
+        public override void OnInspectorGUI()
+        {
+            EditorGUILayout.HelpBox("Steam Audio is not supported for the target platform or STEAMAUDIO_ENABLED define symbol is missing.", MessageType.Warning);
+        }
+#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/AudioEngineSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/AudioEngineSource.cs
@@ -2,6 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
+#if STEAMAUDIO_ENABLED
 
 using UnityEngine;
 
@@ -35,3 +36,5 @@ namespace SteamAudio
         }
     }
 }
+
+#endif

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/AudioEngineState.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/AudioEngineState.cs
@@ -2,6 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
+#if STEAMAUDIO_ENABLED
 
 using System;
 using UnityEngine;
@@ -60,3 +61,5 @@ namespace SteamAudio
         }
     }
 }
+
+#endif

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/Baker.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/Baker.cs
@@ -2,6 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
+#if STEAMAUDIO_ENABLED
 
 using AOT;
 using System;
@@ -334,3 +335,4 @@ namespace SteamAudio
     }
 }
 
+#endif

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/FMODStudioAudioEngineSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/FMODStudioAudioEngineSource.cs
@@ -2,6 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
+#if STEAMAUDIO_ENABLED
 
 using System;
 using System.Reflection;
@@ -170,3 +171,5 @@ namespace SteamAudio
         }
     }
 }
+
+#endif

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/FMODStudioAudioEngineState.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/FMODStudioAudioEngineState.cs
@@ -2,6 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
+#if STEAMAUDIO_ENABLED
 
 using System;
 using System.Reflection;
@@ -93,3 +94,5 @@ namespace SteamAudio
         }
     }
 }
+
+#endif

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/InstancedMesh.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/InstancedMesh.cs
@@ -2,6 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
+#if STEAMAUDIO_ENABLED
 
 using System;
 using UnityEngine;
@@ -61,3 +62,5 @@ namespace SteamAudio
         }
     }
 }
+
+#endif

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/ProbeBatch.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/ProbeBatch.cs
@@ -2,6 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
+#if STEAMAUDIO_ENABLED
 
 using System;
 using UnityEngine;
@@ -136,3 +137,4 @@ namespace SteamAudio
         }
     }
 }
+#endif

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/Scene.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/Scene.cs
@@ -2,6 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
+#if STEAMAUDIO_ENABLED
 
 using System;
 
@@ -32,7 +33,7 @@ namespace SteamAudio
         public Scene(Context context, SceneSettings sceneSettings, SerializedData dataAsset)
         {
             mContext = context;
-
+            
             var serializedObject = new SerializedObject(context, dataAsset);
             var status = API.iplSceneLoad(context.Get(), ref sceneSettings, serializedObject.Get(), null, IntPtr.Zero, out mScene);
             if (status != Error.Success)
@@ -99,3 +100,4 @@ namespace SteamAudio
         }
     }
 }
+#endif

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SerializedObject.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SerializedObject.cs
@@ -2,6 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
+#if STEAMAUDIO_ENABLED
 
 using System;
 using System.Collections.Generic;
@@ -126,3 +127,4 @@ namespace SteamAudio
         }
     }
 }
+#endif

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/Simulator.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/Simulator.cs
@@ -2,6 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
+#if STEAMAUDIO_ENABLED
 
 using System;
 using UnityEngine;
@@ -137,3 +138,4 @@ namespace SteamAudio
         }
     }
 }
+#endif

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/StaticMesh.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/StaticMesh.cs
@@ -2,6 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
+#if STEAMAUDIO_ENABLED
 
 using System;
 using System.Runtime.InteropServices;
@@ -52,7 +53,7 @@ namespace SteamAudio
             if (status != Error.Success)
             {
                 throw new Exception(string.Format("Unable to create static mesh for export ({0} vertices, {1} triangles, {2} materials): [{3}]",
-                    staticMeshSettings.numVertices.ToString(), staticMeshSettings.numTriangles.ToString(), staticMeshSettings.numMaterials.ToString(), 
+                    staticMeshSettings.numVertices.ToString(), staticMeshSettings.numTriangles.ToString(), staticMeshSettings.numMaterials.ToString(),
                     status.ToString()));
             }
 
@@ -120,3 +121,5 @@ namespace SteamAudio
         }
     }
 }
+
+#endif

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioBakedListener.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioBakedListener.cs
@@ -26,6 +26,7 @@ namespace SteamAudio
         [SerializeField]
         SteamAudioProbeBatch[] mProbeBatchesUsed = null;
 
+#if STEAMAUDIO_ENABLED
         public int GetTotalDataSize()
         {
             return mTotalDataSize;
@@ -133,5 +134,6 @@ namespace SteamAudio
         {
             mProbeBatchesUsed = (useAllProbeBatches) ? FindObjectsOfType<SteamAudioProbeBatch>() : probeBatches;
         }
+#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioBakedSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioBakedSource.cs
@@ -26,6 +26,7 @@ namespace SteamAudio
         [SerializeField]
         SteamAudioProbeBatch[] mProbeBatchesUsed = null;
 
+#if STEAMAUDIO_ENABLED
         public int GetTotalDataSize()
         {
             return mTotalDataSize;
@@ -133,5 +134,6 @@ namespace SteamAudio
         {
             mProbeBatchesUsed = (useAllProbeBatches) ? FindObjectsOfType<SteamAudioProbeBatch>() : probeBatches;
         }
+#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioDynamicObject.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioDynamicObject.cs
@@ -14,6 +14,7 @@ namespace SteamAudio
         [Header("Export Settings")]
         public SerializedData asset = null;
 
+#if STEAMAUDIO_ENABLED
         InstancedMesh mInstancedMesh = null;
 
         private void OnDestroy()
@@ -56,5 +57,6 @@ namespace SteamAudio
 
             mInstancedMesh.UpdateTransform(SteamAudioManager.CurrentScene, transform);
         }
+#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioGeometry.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioGeometry.cs
@@ -18,6 +18,7 @@ namespace SteamAudio
         [Range(0, 10)]
         public int terrainSimplificationLevel = 0;
 
+#if STEAMAUDIO_ENABLED
         public int GetNumVertices()
         {
             if (exportAllChildren)
@@ -57,5 +58,6 @@ namespace SteamAudio
                 return SteamAudioManager.GetNumTriangles(gameObject);
             }
         }
+#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioListener.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioListener.cs
@@ -36,6 +36,8 @@ namespace SteamAudio
         BakedDataIdentifier mIdentifier = new BakedDataIdentifier { };
         [SerializeField]
         SteamAudioProbeBatch[] mProbeBatchesUsed = null;
+
+#if STEAMAUDIO_ENABLED
         Simulator mSimulator = null;
         Source mSource = null;
 
@@ -229,5 +231,6 @@ namespace SteamAudio
         {
             mProbeBatchesUsed = (useAllProbeBatches) ? FindObjectsOfType<SteamAudioProbeBatch>() : probeBatches;
         }
+#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioManager.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioManager.cs
@@ -34,6 +34,8 @@ namespace SteamAudio
     {
         [Header("HRTF Settings")]
         public int currentHRTF = 0;
+
+#if STEAMAUDIO_ENABLED
         public string[] hrtfNames = null;
 
         int mNumCPUCores = 0;
@@ -162,7 +164,7 @@ namespace SteamAudio
 
         public int NumThreadsForCPUCorePercentage(int percentage)
         {
-            return (int) Mathf.Max(1, (percentage * mNumCPUCores) / 100.0f);
+            return (int)Mathf.Max(1, (percentage * mNumCPUCores) / 100.0f);
         }
 
         public static SceneType GetSceneType()
@@ -295,8 +297,8 @@ namespace SteamAudio
                 {
                     if (SteamAudioSettings.Singleton.SOFAFiles[i])
                     {
-                        mHRTFs[i + 1] = new HRTF(mContext, mAudioSettings, 
-                            SteamAudioSettings.Singleton.SOFAFiles[i].sofaName, 
+                        mHRTFs[i + 1] = new HRTF(mContext, mAudioSettings,
+                            SteamAudioSettings.Singleton.SOFAFiles[i].sofaName,
                             SteamAudioSettings.Singleton.SOFAFiles[i].data,
                             SteamAudioSettings.Singleton.SOFAFiles[i].volume,
                             SteamAudioSettings.Singleton.SOFAFiles[i].normType);
@@ -360,7 +362,7 @@ namespace SteamAudio
 
                 if (SteamAudioSettings.Singleton.sceneType == SceneType.RadeonRays &&
                     !mOpenCLInitFailed)
-                { 
+                {
                     try
                     {
                         mRadeonRaysInitFailed = false;
@@ -461,6 +463,7 @@ namespace SteamAudio
             }
         }
 
+#if STEAMAUDIO_ENABLED
         private void LateUpdate()
         {
             if (mAudioEngineState == null)
@@ -572,7 +575,8 @@ namespace SteamAudio
                 }
             }
         }
-
+#endif
+        
         void RunSimulationInternal()
         {
             if (mSimulator == null)
@@ -696,7 +700,7 @@ namespace SteamAudio
 
             UnityEngine.AudioSettings.Reset(UnityEngine.AudioSettings.GetConfiguration());
 
-            if ((sSingleton.mEmbreeDevice == null || sSingleton.mEmbreeDevice.Get() == IntPtr.Zero) 
+            if ((sSingleton.mEmbreeDevice == null || sSingleton.mEmbreeDevice.Get() == IntPtr.Zero)
                 && SteamAudioSettings.Singleton.sceneType == SceneType.Embree)
             {
                 try
@@ -859,7 +863,7 @@ namespace SteamAudio
             {
                 var scene = SceneManager.GetSceneAt(i);
 
-                EditorUtility.DisplayProgressBar("Steam Audio", string.Format("Exporting scene: {0}", scene.name), (float) i / (float) SceneManager.sceneCount);
+                EditorUtility.DisplayProgressBar("Steam Audio", string.Format("Exporting scene: {0}", scene.name), (float)i / (float)SceneManager.sceneCount);
 
                 if (!scene.isLoaded)
                 {
@@ -881,7 +885,7 @@ namespace SteamAudio
             {
                 var scene = SceneManager.GetSceneByBuildIndex(i);
 
-                EditorUtility.DisplayProgressBar("Steam Audio", string.Format("Exporting scene: {0}", scene.name), (float) i / (float) SceneManager.sceneCountInBuildSettings);
+                EditorUtility.DisplayProgressBar("Steam Audio", string.Format("Exporting scene: {0}", scene.name), (float)i / (float)SceneManager.sceneCountInBuildSettings);
 
                 var shouldClose = false;
                 if (!scene.isLoaded)
@@ -921,7 +925,7 @@ namespace SteamAudio
             {
                 var scene = SceneManager.GetSceneAt(i);
 
-                EditorUtility.DisplayProgressBar("Steam Audio", string.Format("Exporting dynamic objects in scene: {0}", scene.name), (float) i / (float) SceneManager.sceneCount);
+                EditorUtility.DisplayProgressBar("Steam Audio", string.Format("Exporting dynamic objects in scene: {0}", scene.name), (float)i / (float)SceneManager.sceneCount);
 
                 if (!scene.isLoaded)
                 {
@@ -943,7 +947,7 @@ namespace SteamAudio
             {
                 var scene = SceneManager.GetSceneByBuildIndex(i);
 
-                EditorUtility.DisplayProgressBar("Steam Audio", string.Format("Exporting dynamic objects in scene: {0}", scene.name), (float) i / (float) SceneManager.sceneCountInBuildSettings);
+                EditorUtility.DisplayProgressBar("Steam Audio", string.Format("Exporting dynamic objects in scene: {0}", scene.name), (float)i / (float)SceneManager.sceneCountInBuildSettings);
 
                 var shouldClose = false;
                 if (!scene.isLoaded)
@@ -973,17 +977,17 @@ namespace SteamAudio
             var numItems = scenes.Length + prefabs.Length;
 
             var index = 0;
-            foreach (var sceneGUID in scenes) 
+            foreach (var sceneGUID in scenes)
             {
                 var scenePath = AssetDatabase.GUIDToAssetPath(sceneGUID);
 
-                EditorUtility.DisplayProgressBar("Steam Audio", string.Format("Exporting dynamic objects in scene: {0}", scenePath), (float) index / (float) numItems);
+                EditorUtility.DisplayProgressBar("Steam Audio", string.Format("Exporting dynamic objects in scene: {0}", scenePath), (float)index / (float)numItems);
 
                 var activeScene = EditorSceneManager.GetActiveScene();
                 var isLoadedScene = (scenePath == activeScene.path);
 
                 var scene = activeScene;
-                if (!isLoadedScene) 
+                if (!isLoadedScene)
                 {
 #if UNITY_2019_2_OR_NEWER
                     var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssetPath(scenePath);
@@ -999,7 +1003,7 @@ namespace SteamAudio
 
                 ExportDynamicObjectsInArray(GetDynamicObjectsInScene(scene));
 
-                if (!isLoadedScene) 
+                if (!isLoadedScene)
                 {
                     EditorSceneManager.CloseScene(scene, true);
                 }
@@ -1007,11 +1011,11 @@ namespace SteamAudio
                 ++index;
             }
 
-            foreach (var prefabGUID in prefabs) 
+            foreach (var prefabGUID in prefabs)
             {
                 var prefabPath = AssetDatabase.GUIDToAssetPath(prefabGUID);
 
-                EditorUtility.DisplayProgressBar("Steam Audio", string.Format("Exporting dynamic objects in prefab: {0}", prefabPath), (float) index / (float) numItems);
+                EditorUtility.DisplayProgressBar("Steam Audio", string.Format("Exporting dynamic objects in prefab: {0}", prefabPath), (float)index / (float)numItems);
 
                 var prefab = AssetDatabase.LoadMainAssetAtPath(prefabPath) as GameObject;
                 var dynamicObjects = prefab.GetComponentsInChildren<SteamAudioDynamicObject>();
@@ -1043,7 +1047,7 @@ namespace SteamAudio
             var FMODUnity_Settings_Instance = FMODUnity_Settings.GetProperty("Instance");
             var FMODUnity_Settings_CurrentVersion = FMODUnity_Settings.GetField("CurrentVersion");
             var fmodSettings = FMODUnity_Settings_Instance.GetValue(null, null);
-            var fmodVersion = (int) FMODUnity_Settings_CurrentVersion.GetValue(fmodSettings);
+            var fmodVersion = (int)FMODUnity_Settings_CurrentVersion.GetValue(fmodSettings);
             var fmodVersionMajor = (fmodVersion & 0x00ff0000) >> 16;
             var fmodVersionMinor = (fmodVersion & 0x0000ff00) >> 8;
             var fmodVersionPatch = (fmodVersion & 0x000000ff);
@@ -1103,7 +1107,7 @@ namespace SteamAudio
 
                     moveSucceeded = MoveAssets(moves);
                 }
-            } 
+            }
             else
             {
                 EditorUtility.DisplayDialog("Steam Audio",
@@ -1378,7 +1382,7 @@ namespace SteamAudio
 
                 var w = terrain.terrainData.heightmapResolution;
                 var h = terrain.terrainData.heightmapResolution;
-                var s = Mathf.Min(w - 1, Mathf.Min(h - 1, (int) Mathf.Pow(2.0f, terrainSimplificationLevel)));
+                var s = Mathf.Min(w - 1, Mathf.Min(h - 1, (int)Mathf.Pow(2.0f, terrainSimplificationLevel)));
 
                 if (s == 0)
                 {
@@ -1412,7 +1416,7 @@ namespace SteamAudio
 
                 var w = terrain.terrainData.heightmapResolution;
                 var h = terrain.terrainData.heightmapResolution;
-                var s = Mathf.Min(w - 1, Mathf.Min(h - 1, (int) Mathf.Pow(2.0f, terrainSimplificationLevel)));
+                var s = Mathf.Min(w - 1, Mathf.Min(h - 1, (int)Mathf.Pow(2.0f, terrainSimplificationLevel)));
 
                 if (s == 0)
                 {
@@ -1471,7 +1475,7 @@ namespace SteamAudio
 
             var numHits = Physics.RaycastNonAlloc(origin, direction, sSingleton.mRayHits, maxDistance, layerMask);
 
-            occluded = (byte) ((numHits > 0) ? 1 : 0);
+            occluded = (byte)((numHits > 0) ? 1 : 0);
         }
 
         // This method is called as soon as scripts are loaded, which happens whenever play mode is started
@@ -1551,7 +1555,7 @@ namespace SteamAudio
         {
             var sceneType = GetSceneType();
 
-            var scene = new Scene(context, sceneType, sSingleton.mEmbreeDevice, sSingleton.mRadeonRaysDevice, 
+            var scene = new Scene(context, sceneType, sSingleton.mEmbreeDevice, sSingleton.mRadeonRaysDevice,
                 ClosestHit, AnyHit);
 
             if (sceneType == SceneType.Custom)
@@ -1656,7 +1660,7 @@ namespace SteamAudio
         static bool IsDynamicSubObject(GameObject root, GameObject obj)
         {
             return (root.GetComponentInParent<SteamAudioDynamicObject>() !=
-                    obj.GetComponentInParent<SteamAudioDynamicObject>());
+                obj.GetComponentInParent<SteamAudioDynamicObject>());
         }
 
         // Ideally, we want to use GameObject.activeInHierarchy to check if a GameObject is active. However, when
@@ -1766,7 +1770,7 @@ namespace SteamAudio
 
                 var w = terrain.terrainData.heightmapResolution;
                 var h = terrain.terrainData.heightmapResolution;
-                var s = Mathf.Min(w - 1, Mathf.Min(h - 1, (int) Mathf.Pow(2.0f, terrainSimplificationLevel)));
+                var s = Mathf.Min(w - 1, Mathf.Min(h - 1, (int)Mathf.Pow(2.0f, terrainSimplificationLevel)));
                 if (s == 0)
                 {
                     s = 1;
@@ -1824,7 +1828,7 @@ namespace SteamAudio
 
                 var w = terrain.terrainData.heightmapResolution;
                 var h = terrain.terrainData.heightmapResolution;
-                var s = Mathf.Min(w - 1, Mathf.Min(h - 1, (int) Mathf.Pow(2.0f, terrainSimplificationLevel)));
+                var s = Mathf.Min(w - 1, Mathf.Min(h - 1, (int)Mathf.Pow(2.0f, terrainSimplificationLevel)));
                 if (s == 0)
                 {
                     s = 1;
@@ -2009,5 +2013,6 @@ namespace SteamAudio
         {
             return dynamicObject.asset;
         }
+#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioProbeBatch.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioProbeBatch.cs
@@ -38,6 +38,7 @@ namespace SteamAudio
         [SerializeField] Sphere[] mProbeSpheres = null;
         [SerializeField] List<BakedDataLayerInfo> mBakedDataLayerInfo = new List<BakedDataLayerInfo>();
 
+#if STEAMAUDIO_ENABLED
         ProbeBatch mProbeBatch = null;
 
         const float kProbeDrawSize = 0.1f;
@@ -327,5 +328,6 @@ namespace SteamAudio
 
             Baker.BeginBake(tasks);
         }
+#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioSource.cs
@@ -140,6 +140,7 @@ namespace SteamAudio
         [Range(0.0f, 10.0f)]
         public float pathingMixLevel = 1.0f;
 
+#if STEAMAUDIO_ENABLED
         Simulator mSimulator = null;
         Source mSource = null;
         AudioEngineSource mAudioEngineSource = null;
@@ -522,5 +523,6 @@ namespace SteamAudio
                     return 0.0f;
             }
         }
+#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioStaticMesh.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioStaticMesh.cs
@@ -13,6 +13,7 @@ namespace SteamAudio
         public SerializedData asset = null;
         public string sceneNameWhenExported = "";
 
+#if STEAMAUDIO_ENABLED
         StaticMesh mStaticMesh = null;
 
         void Start()
@@ -60,5 +61,6 @@ namespace SteamAudio
                 }
             }
         }
+#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/UnityAudioEngineSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/UnityAudioEngineSource.cs
@@ -2,6 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
+#if STEAMAUDIO_ENABLED
 
 using System;
 using UnityEngine;
@@ -78,3 +79,5 @@ namespace SteamAudio
         }
     }
 }
+
+#endif

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/UnityAudioEngineState.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/UnityAudioEngineState.cs
@@ -2,6 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
+#if STEAMAUDIO_ENABLED
 
 using System;
 using UnityEngine;
@@ -60,3 +61,5 @@ namespace SteamAudio
         }
     }
 }
+
+#endif

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/SteamAudioUnity.asmdef
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/SteamAudioUnity.asmdef
@@ -2,14 +2,7 @@
     "name": "SteamAudioUnity",
     "rootNamespace": "",
     "references": [],
-    "includePlatforms": [
-        "Android",
-        "Editor",
-        "LinuxStandalone64",
-        "macOSStandalone",
-        "WindowsStandalone32",
-        "WindowsStandalone64"
-    ],
+    "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,


### PR DESCRIPTION
in 4.4.1, STEAMAUDIO_ENABLED was added to indicate Steam Audio is present in the project and it is on a supported platform.

However, in a lot of cases, most Steam Audio components will still present in the scenes and prefabs, which would create a lot of broken prefabs and missing scripts for existing project to port onto a unsupported platform.

By wrapping all Steam Audio code in STEAMAUDIO_ENABLED besides serialized fields in components, we can stop Steam Audio from ever running while keeping all the prefab and serialized data intact when switching platforms without losing components or data.

As a bonus, this also prevents Steam Audio from running in Dedicated Server build since it is not a "supported platform" with STEAMAUDIO_ENABLED symbol enabled even though the binary can be bundled.

This however does not mean a fallback to unity audio or fmod, it is still up to the developer to make sure they config and play the audio accordingly (and maybe strip unused SteamAudio data when building). But it would be much easier to get started without having to manually remove all existing Steam Audio components just to make the errors go away.

_The C# targeted platform is also restored to all platforms since the code can dry run and it is designed to keep the components._