### PR TITLE
[Unity] Perormance optimizations concerning calling mCurrentScene.Commit(); in LateUpdate

### DIFF
--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioDynamicObject.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioDynamicObject.cs
@@ -32,7 +32,7 @@ namespace SteamAudio
             if (mInstancedMesh != null)
             {
                 mInstancedMesh.AddToScene(SteamAudioManager.CurrentScene);
-                SteamAudioManager.CommitScene();
+                SteamAudioManager.ScheduleCommitScene();
             }
         }
 
@@ -41,7 +41,7 @@ namespace SteamAudio
             if (mInstancedMesh != null && SteamAudioManager.CurrentScene != null)
             {
                 mInstancedMesh.RemoveFromScene(SteamAudioManager.CurrentScene);
-                SteamAudioManager.CommitScene();
+                SteamAudioManager.ScheduleCommitScene();
             }
         }
 
@@ -54,13 +54,15 @@ namespace SteamAudio
                 if (enabled)
                 {
                     mInstancedMesh.AddToScene(SteamAudioManager.CurrentScene);
-                    SteamAudioManager.CommitScene();
+                    SteamAudioManager.ScheduleCommitScene();
                 }
             }
-            if (transform.hasChanged) // Only update the dynamic object if it has actually move this frame
+
+            // Only update the dynamic object if it has actually move this frame
+            if (transform.hasChanged)
             {
                 mInstancedMesh.UpdateTransform(SteamAudioManager.CurrentScene, transform);
-                SteamAudioManager.CommitScene();
+                SteamAudioManager.ScheduleCommitScene();
                 transform.hasChanged = false;
             }
         }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioDynamicObject.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioDynamicObject.cs
@@ -31,6 +31,7 @@ namespace SteamAudio
             if (mInstancedMesh != null)
             {
                 mInstancedMesh.AddToScene(SteamAudioManager.CurrentScene);
+                SteamAudioManager.CommitScene();
             }
         }
 
@@ -39,6 +40,7 @@ namespace SteamAudio
             if (mInstancedMesh != null && SteamAudioManager.CurrentScene != null)
             {
                 mInstancedMesh.RemoveFromScene(SteamAudioManager.CurrentScene);
+                SteamAudioManager.CommitScene();
             }
         }
 
@@ -51,10 +53,15 @@ namespace SteamAudio
                 if (enabled)
                 {
                     mInstancedMesh.AddToScene(SteamAudioManager.CurrentScene);
+                    SteamAudioManager.CommitScene();
                 }
             }
-
-            mInstancedMesh.UpdateTransform(SteamAudioManager.CurrentScene, transform);
+            if (transform.hasChanged) // Only update the dynamic object if it has actually move this frame
+            {
+                mInstancedMesh.UpdateTransform(SteamAudioManager.CurrentScene, transform);
+                SteamAudioManager.CommitScene();
+                transform.hasChanged = false;
+            }
         }
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioManager.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioManager.cs
@@ -461,6 +461,12 @@ namespace SteamAudio
             }
         }
 
+        //Call this function to commit changes to a scene only when changes have happened 
+        public static void CommitScene()
+        {
+            sSingleton.mCurrentScene.Commit();
+        }
+
         private void LateUpdate()
         {
             if (mAudioEngineState == null)
@@ -476,7 +482,7 @@ namespace SteamAudio
 
             if (mSimulationThread.ThreadState == ThreadState.WaitSleepJoin)
             {
-                mCurrentScene.Commit();
+               // mCurrentScene.Commit(); // This was causing lag spikes of up to 55ms
 
                 mSimulator.SetScene(mCurrentScene);
                 mSimulator.Commit();

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioStaticMesh.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioStaticMesh.cs
@@ -38,7 +38,7 @@ namespace SteamAudio
             if (mStaticMesh != null)
             {
                 mStaticMesh.AddToScene(SteamAudioManager.CurrentScene);
-                SteamAudioManager.CommitScene();
+                SteamAudioManager.ScheduleCommitScene();
             }
         }
 
@@ -47,7 +47,7 @@ namespace SteamAudio
             if (mStaticMesh != null && SteamAudioManager.CurrentScene != null)
             {
                 mStaticMesh.RemoveFromScene(SteamAudioManager.CurrentScene);
-                SteamAudioManager.CommitScene();
+                SteamAudioManager.ScheduleCommitScene();
             }
         }
 
@@ -60,7 +60,7 @@ namespace SteamAudio
                 if (enabled)
                 {
                     mStaticMesh.AddToScene(SteamAudioManager.CurrentScene);
-                    SteamAudioManager.CommitScene();
+                    SteamAudioManager.ScheduleCommitScene();
                 }
             }
         }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioStaticMesh.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioStaticMesh.cs
@@ -37,6 +37,7 @@ namespace SteamAudio
             if (mStaticMesh != null)
             {
                 mStaticMesh.AddToScene(SteamAudioManager.CurrentScene);
+                SteamAudioManager.CommitScene();
             }
         }
 
@@ -45,6 +46,7 @@ namespace SteamAudio
             if (mStaticMesh != null && SteamAudioManager.CurrentScene != null)
             {
                 mStaticMesh.RemoveFromScene(SteamAudioManager.CurrentScene);
+                SteamAudioManager.CommitScene();
             }
         }
 
@@ -57,6 +59,7 @@ namespace SteamAudio
                 if (enabled)
                 {
                     mStaticMesh.AddToScene(SteamAudioManager.CurrentScene);
+                    SteamAudioManager.CommitScene();
                 }
             }
         }


### PR DESCRIPTION
## Description
During the development of our current game we noticed that the ```LateUpdate``` method of ```SteamAudioManger``` was producing lag spikes of up to 60ms. See screenshot bellow: 
	
![ScreenshotSteamAudioLagSpike](https://github.com/ValveSoftware/steam-audio/assets/4999276/b394ca56-c64e-4a3b-bc4e-c9d7eefcbe11)

What we did was deep profile and establish that the culprit was the regular call to 
```mCurrentScene.Commit()```

## What we did 
We isolated the call to ```cs mCurrentScene.Commit()``` in it's own method ```CommitScene()``` inside ```SteamAudioManager``` and then called that method in the relevant places of ```SteamAudioDynamicObject``` and ```SteamAudioStaticMesh```
Additionally a ```transform.hasChanged``` was added to ```SteamAudioDynamicObject``` so that changes are only committed if the object has moved this frame.
After this change we did not notice the introduction of any bugs or discrepancies in how the audio was played, but the lag spikes were gone and   ```LateUpdate```  now takes between 0.1ms and 0.3ms on average 
![ScreenshotSteamAudioNoLagSpike](https://github.com/ValveSoftware/steam-audio/assets/4999276/48a43df3-5212-4db0-9869-244e6ac4c511)
