### PR TITLE
Allow user to manually toggle STEAMAUDIO_DISABLED define

### DIFF
--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/Build.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/Build.cs
@@ -29,26 +29,4 @@ namespace SteamAudio
             AssetDatabase.ExportPackage(assets, fileName, ExportPackageOptions.Recurse);
         }
     }
-
-    [InitializeOnLoad]
-    public static class Defines
-    {
-        // Define the constant STEAMAUDIO_ENABLED for all platforms that are supported by
-        // Steam Audio. User scripts should check if this constant is defined
-        // (using #if STEAMAUDIO_ENABLED) before using any of the Steam Audio C# classes.
-        static Defines()
-        {
-#if UNITY_2021_2_OR_NEWER
-            NamedBuildTarget[] supportedPlatforms = {
-                NamedBuildTarget.Standalone,
-                NamedBuildTarget.Android,
-            };
-
-            foreach (var supportedPlatform in supportedPlatforms)
-            {
-                PlayerSettings.SetScriptingDefineSymbols(supportedPlatform, "STEAMAUDIO_ENABLED");
-            }
-#endif
-        }
-    }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SOFAFileEditor.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SOFAFileEditor.cs
@@ -11,9 +11,9 @@ namespace SteamAudio
      * Custom editor GUI for SOFAFile assets.
      */
     [CustomEditor(typeof(SOFAFile))]
-    public class SOFAFileEditor : Editor
+    public class SOFAFileEditor : SteamAudioEditor
     {
-        public override void OnInspectorGUI()
+        protected override void OnSteamAudioGUI()
         {
             EditorGUILayout.PropertyField(serializedObject.FindProperty("sofaName"));
             EditorGUILayout.LabelField("Size", Common.HumanReadableDataSize(serializedObject.FindProperty("data").arraySize));

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SerializedDataInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SerializedDataInspector.cs
@@ -8,7 +8,7 @@ using UnityEditor;
 namespace SteamAudio
 {
     [CustomEditor(typeof(SerializedData))]
-    public class SerializedDataInspector : Editor
+    public class SerializedDataInspector : SteamAudioEditor
     {
         SerializedProperty mData;
 
@@ -17,7 +17,7 @@ namespace SteamAudio
             mData = serializedObject.FindProperty("data");
         }
 
-        public override void OnInspectorGUI()
+        protected override void OnSteamAudioGUI()
         {
             serializedObject.Update();
 

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioAmbisonicSourceInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioAmbisonicSourceInspector.cs
@@ -9,7 +9,7 @@ namespace SteamAudio
 {
     [CustomEditor(typeof(SteamAudioAmbisonicSource))]
     [CanEditMultipleObjects]
-    public class SteamAudioAmbisonicSourceInspector : Editor
+    public class SteamAudioAmbisonicSourceInspector : SteamAudioEditor
     {
         SerializedProperty mApplyHRTF;
 
@@ -18,7 +18,7 @@ namespace SteamAudio
             mApplyHRTF = serializedObject.FindProperty("applyHRTF");
         }
 
-        public override void OnInspectorGUI()
+        protected override void OnSteamAudioGUI()
         {
             if (SteamAudioSettings.Singleton.audioEngine != AudioEngineType.Unity)
             {

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioBakedListenerInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioBakedListenerInspector.cs
@@ -9,9 +9,8 @@ using UnityEditor;
 namespace SteamAudio
 {
     [CustomEditor(typeof(SteamAudioBakedListener))]
-    public class SteamAudioBakedListenerInspector : Editor
+    public class SteamAudioBakedListenerInspector : SteamAudioEditor
     {
-#if STEAMAUDIO_ENABLED
         SerializedProperty mInfluenceRadius;
         SerializedProperty mUseAllProbeBatches;
         SerializedProperty mProbeBatches;
@@ -26,7 +25,7 @@ namespace SteamAudio
             mProbeBatches = serializedObject.FindProperty("probeBatches");
         }
 
-        public override void OnInspectorGUI()
+        protected override void OnSteamAudioGUI()
         {
             serializedObject.Update();
 
@@ -76,11 +75,5 @@ namespace SteamAudio
 
             serializedObject.ApplyModifiedProperties();
         }
-#else
-        public override void OnInspectorGUI()
-        {
-            EditorGUILayout.HelpBox("Steam Audio is not supported for the target platform or STEAMAUDIO_ENABLED define symbol is missing.", MessageType.Warning);
-        }
-#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioBakedSourceInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioBakedSourceInspector.cs
@@ -9,9 +9,8 @@ using UnityEditor;
 namespace SteamAudio
 {
     [CustomEditor(typeof(SteamAudioBakedSource))]
-    public class SteamAudioBakedSourceInspector : Editor
+    public class SteamAudioBakedSourceInspector : SteamAudioEditor
     {
-#if STEAMAUDIO_ENABLED
         SerializedProperty mInfluenceRadius;
         SerializedProperty mUseAllProbeBatches;
         SerializedProperty mProbeBatches;
@@ -26,7 +25,7 @@ namespace SteamAudio
             mProbeBatches = serializedObject.FindProperty("probeBatches");
         }
 
-        public override void OnInspectorGUI()
+        protected override void OnSteamAudioGUI()
         {
             serializedObject.Update();
 
@@ -76,11 +75,5 @@ namespace SteamAudio
 
             serializedObject.ApplyModifiedProperties();
         }
-#else
-        public override void OnInspectorGUI()
-        {
-            EditorGUILayout.HelpBox("Steam Audio is not supported for the target platform or STEAMAUDIO_ENABLED define symbol is missing.", MessageType.Warning);
-        }
-#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioDynamicObjectInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioDynamicObjectInspector.cs
@@ -10,9 +10,8 @@ using UnityEngine;
 namespace SteamAudio
 {
     [CustomEditor(typeof(SteamAudioDynamicObject))]
-    public class SteamAudioDynamicObjectInspector : Editor
+    public class SteamAudioDynamicObjectInspector : SteamAudioEditor
     {
- #if STEAMAUDIO_ENABLED
         SerializedProperty mAsset;
 
         private void OnEnable()
@@ -20,7 +19,7 @@ namespace SteamAudio
             mAsset = serializedObject.FindProperty("asset");
         }
 
-        public override void OnInspectorGUI()
+        protected override void OnSteamAudioGUI()
         {
             serializedObject.Update();
 
@@ -54,11 +53,5 @@ namespace SteamAudio
 
             serializedObject.ApplyModifiedProperties();
         }
-#else
-        public override void OnInspectorGUI()
-        {
-            EditorGUILayout.HelpBox("Steam Audio is not supported for the target platform or STEAMAUDIO_ENABLED define symbol is missing.", MessageType.Warning);
-        }
-#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioEditor.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioEditor.cs
@@ -1,0 +1,145 @@
+//
+// Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
+// https://valvesoftware.github.io/steam-audio/license.html
+//
+
+using System.Linq;
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEngine;
+
+namespace SteamAudio
+{
+    public abstract class SteamAudioEditor : Editor
+    {
+        private static class Styles
+        {
+            public static readonly GUIContent sDisableButton = new GUIContent("Disable Steam Audio", $"Click this button to automatically add the STEAMAUDIO_DISABLED define symbol for this target");
+            public static readonly GUIContent sEnableButton = new GUIContent("Enable Steam Audio", "Click this button to automatically remove the STEAMAUDIO_DISABLED define symbol for this target");
+        }
+        
+        static bool? sNativePluginAvailableForTarget = null;
+        public static bool NativePluginAvailableForTarget
+        {
+            get
+            {
+                if (sNativePluginAvailableForTarget != null)
+                    return sNativePluginAvailableForTarget.Value;
+
+                sNativePluginAvailableForTarget = AssetDatabase.FindAssets("phonon t:DefaultAsset")
+                    .Select(guid => AssetImporter.GetAtPath(AssetDatabase.GUIDToAssetPath(guid)) as PluginImporter)
+                    .Where(plugin => plugin != null)
+                    .Any(IsNativePluginCompatibleWithActiveTarget);
+
+                return sNativePluginAvailableForTarget.Value;
+            }
+        }
+
+        private static bool IsNativePluginCompatibleWithActiveTarget(PluginImporter plugin)
+        {
+            // A standalone plugin will be considered as compatible to all standalone targets.
+            // Since Steam Audio provides binary for all standalone platform, telling them apart is not a concern.
+            // https://github.com/Unity-Technologies/UnityCsReference/blob/2021.3/Modules/AssetPipelineEditor/ImportSettings/PluginImporterInspector.cs#L28
+
+            if (!plugin.isNativePlugin) return false;
+            if (!plugin.GetCompatibleWithPlatform(EditorUserBuildSettings.activeBuildTarget)) return false;
+            return true;
+        }
+
+#if UNITY_2021_2_OR_NEWER
+        public static NamedBuildTarget GetActiveNamedBuildTarget()
+        {
+#if UNITY_SERVER
+            return NamedBuildTarget.Server;
+#endif
+            var targetGroup = BuildPipeline.GetBuildTargetGroup(EditorUserBuildSettings.activeBuildTarget);
+            return NamedBuildTarget.FromBuildTargetGroup(targetGroup);
+        }
+
+        public static void AddDefineSymbolsToTarget(string define)
+        {
+            var target = GetActiveNamedBuildTarget();
+            var defines = PlayerSettings.GetScriptingDefineSymbols(target);
+            var defineList = defines.Split(';').ToList();
+            if (defineList.IndexOf(define) < 0)
+            {
+                PlayerSettings.SetScriptingDefineSymbols(target, defines + ";" + define);
+            }
+        }
+
+        public static void RemoveDefineSymbolsToTarget(string define)
+        {
+            var target = GetActiveNamedBuildTarget();
+            var defines = PlayerSettings.GetScriptingDefineSymbols(target).Split(';').ToList();
+            defines.Remove(define);
+            PlayerSettings.SetScriptingDefineSymbols(target, string.Join(';', defines));
+        }
+#else
+        public static void AddDefineSymbolsToTarget(string define)
+        {
+            var target = BuildPipeline.GetBuildTargetGroup(EditorUserBuildSettings.activeBuildTarget);
+            var defines = PlayerSettings.GetScriptingDefineSymbolsForGroup(target).Split(';').ToList();
+            if (defines.IndexOf(define) < 0)
+            {
+                PlayerSettings.SetScriptingDefineSymbolsForGroup(target, defines + ";" + define);
+            }
+        }
+
+        public static void RemoveDefineSymbolsToTarget(string define)
+        {
+            var target = BuildPipeline.GetBuildTargetGroup(EditorUserBuildSettings.activeBuildTarget);
+            var defines = PlayerSettings.GetScriptingDefineSymbolsForGroup(target).Split(';').ToList();
+            defines.Remove(define);
+            PlayerSettings.SetScriptingDefineSymbolsForGroup(target, string.Join(';', defines));
+        }
+#endif
+
+        protected virtual bool AlwaysShowSteamAudioToggle { get; set; } = false;
+
+        public override void OnInspectorGUI()
+        {
+            if (EditorApplication.isCompiling) return;
+
+#if STEAMAUDIO_DISABLED
+            if (NativePluginAvailableForTarget)
+            {
+                EditorGUILayout.HelpBox("Steam Audio is disabled for {EditorUserBuildSettings.activeBuildTarget}.\nSteam Audio native plugin found for {EditorUserBuildSettings.activeBuildTarget}.\nYou can enable Steam Audio by removing the STEAMAUDIO_DISABLED define symbol.", MessageType.Info);
+                if (GUILayout.Button(Styles.sEnableButton))
+                {
+                    RemoveDefineSymbolsToTarget("STEAMAUDIO_DISABLED");
+                }
+            }
+            else
+            {
+                EditorGUILayout.HelpBox("Steam Audio is disabled for {EditorUserBuildSettings.activeBuildTarget}.", AlwaysShowSteamAudioToggle ? MessageType.Info : MessageType.None);
+                if (AlwaysShowSteamAudioToggle && GUILayout.Button(Styles.sEnableButton))
+                {
+                    RemoveDefineSymbolsToTarget("STEAMAUDIO_DISABLED");
+                }
+            }
+#else
+            if (!NativePluginAvailableForTarget)
+            {
+                EditorGUILayout.HelpBox($"Steam Audio native plugin is not available for {EditorUserBuildSettings.activeBuildTarget}.\nYou can disable Steam Audio by adding a STEAMAUDIO_DISABLED define symbol to prevent Steam Audio from loading on this platform.", MessageType.Warning);
+                if (GUILayout.Button(Styles.sDisableButton))
+                {
+                    AddDefineSymbolsToTarget("STEAMAUDIO_DISABLED");
+                }
+            }
+            else if (AlwaysShowSteamAudioToggle)
+            {
+                // In case user want to disable Steam Audio on supported platform,
+                // this disable button will only show up in Steam Audio Settings.
+                EditorGUILayout.HelpBox($"Steam Audio is enabled for {EditorUserBuildSettings.activeBuildTarget}.", MessageType.Info);
+                if (GUILayout.Button(Styles.sDisableButton))
+                {
+                    AddDefineSymbolsToTarget("STEAMAUDIO_DISABLED");
+                }
+            }
+#endif
+            OnSteamAudioGUI();
+        }
+
+        protected virtual void OnSteamAudioGUI() {}
+    }
+}

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioEditor.cs.meta
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 001cddafae764ae41afccf6cc148ef87
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioGeometryInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioGeometryInspector.cs
@@ -10,9 +10,8 @@ namespace SteamAudio
 {
     [CustomEditor(typeof(SteamAudioGeometry))]
     [CanEditMultipleObjects]
-    public class SteamAudioGeometryInspector : Editor
+    public class SteamAudioGeometryInspector : SteamAudioEditor
     {
-#if STEAMAUDIO_ENABLED
         SerializedProperty mMaterial;
         SerializedProperty mExportAllChildren;
         SerializedProperty mTerrainSimplificationLevel;
@@ -24,7 +23,7 @@ namespace SteamAudio
             mTerrainSimplificationLevel = serializedObject.FindProperty("terrainSimplificationLevel");
         }
 
-        public override void OnInspectorGUI()
+        protected override void OnSteamAudioGUI()
         {
             serializedObject.Update();
 
@@ -49,11 +48,5 @@ namespace SteamAudio
 
             serializedObject.ApplyModifiedProperties();
         }
-#else
-        public override void OnInspectorGUI()
-        {
-            EditorGUILayout.HelpBox("Steam Audio is not supported for the target platform or STEAMAUDIO_ENABLED define symbol is missing.", MessageType.Warning);
-        }
-#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioListenerInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioListenerInspector.cs
@@ -9,9 +9,8 @@ using UnityEditor;
 namespace SteamAudio
 {
     [CustomEditor(typeof(SteamAudioListener))]
-    public class SteamAudioListenerInspector : Editor
+    public class SteamAudioListenerInspector : SteamAudioEditor
     {
-#if STEAMAUDIO_ENABLED
         SerializedProperty mCurrentBakedListener;
         SerializedProperty mApplyReverb;
         SerializedProperty mReverbType;
@@ -30,7 +29,7 @@ namespace SteamAudio
             mProbeBatches = serializedObject.FindProperty("probeBatches");
         }
 
-        public override void OnInspectorGUI()
+        protected override void OnSteamAudioGUI()
         {
             serializedObject.Update();
 
@@ -87,11 +86,5 @@ namespace SteamAudio
 
             serializedObject.ApplyModifiedProperties();
         }
-#else
-        public override void OnInspectorGUI()
-        {
-            EditorGUILayout.HelpBox("Steam Audio is not supported for the target platform or STEAMAUDIO_ENABLED define symbol is missing.", MessageType.Warning);
-        }
-#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioManagerInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioManagerInspector.cs
@@ -9,9 +9,8 @@ namespace SteamAudio
 {
     [CustomEditor(typeof(SteamAudioManager))]
     [CanEditMultipleObjects]
-    public class SteamAudioManagerInspector : Editor
+    public class SteamAudioManagerInspector : SteamAudioEditor
     {
-#if STEAMAUDIO_ENABLED
         SerializedProperty mCurrentHRTF;
 
         private void OnEnable()
@@ -19,7 +18,7 @@ namespace SteamAudio
             mCurrentHRTF = serializedObject.FindProperty("currentHRTF");
         }
 
-        public override void OnInspectorGUI()
+        protected override void OnSteamAudioGUI()
         {
             serializedObject.Update();
 
@@ -36,11 +35,5 @@ namespace SteamAudio
 
             serializedObject.ApplyModifiedProperties();
         }
-#else
-        public override void OnInspectorGUI()
-        {
-            EditorGUILayout.HelpBox("Steam Audio is not supported for the target platform or STEAMAUDIO_ENABLED define symbol is missing.", MessageType.Warning);
-        }
-#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioMaterialInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioMaterialInspector.cs
@@ -9,7 +9,7 @@ namespace SteamAudio
 {
     [CustomEditor(typeof(SteamAudioMaterial))]
     [CanEditMultipleObjects]
-    public class SteamAudioMaterialInspector : Editor
+    public class SteamAudioMaterialInspector : SteamAudioEditor
     {
         SerializedProperty lowFreqAbsorption;
         SerializedProperty midFreqAbsorption;
@@ -30,7 +30,7 @@ namespace SteamAudio
             highFreqTransmission = serializedObject.FindProperty("highFreqTransmission");
         }
 
-        public override void OnInspectorGUI()
+        protected override void OnSteamAudioGUI()
         {
             serializedObject.Update();
 

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioProbeBatchInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioProbeBatchInspector.cs
@@ -11,9 +11,8 @@ using UnityEditor.SceneManagement;
 namespace SteamAudio
 {
     [CustomEditor(typeof(SteamAudioProbeBatch))]
-    public class SteamAudioProbeBatchInspector : Editor
+    public class SteamAudioProbeBatchInspector : SteamAudioEditor
     {
-#if STEAMAUDIO_ENABLED
         SerializedProperty mPlacementStrategy;
         SerializedProperty mHorizontalSpacing;
         SerializedProperty mHeightAboveFloor;
@@ -29,7 +28,7 @@ namespace SteamAudio
             mAsset = serializedObject.FindProperty("asset");
         }
 
-        public override void OnInspectorGUI()
+        protected override void OnSteamAudioGUI()
         {
             serializedObject.Update();
 
@@ -122,11 +121,5 @@ namespace SteamAudio
 
             serializedObject.ApplyModifiedProperties();
         }
-#else
-        public override void OnInspectorGUI()
-        {
-            EditorGUILayout.HelpBox("Steam Audio is not supported for the target platform or STEAMAUDIO_ENABLED define symbol is missing.", MessageType.Warning);
-        }
-#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioSettingsInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioSettingsInspector.cs
@@ -9,7 +9,7 @@ namespace SteamAudio
 {
     [CustomEditor(typeof(SteamAudioSettings))]
     [CanEditMultipleObjects]
-    public class SteamAudioSettingsInspector : Editor
+    public class SteamAudioSettingsInspector : SteamAudioEditor
     {
         SerializedProperty mAudioEngine;
         SerializedProperty mPerspectiveCorrection;
@@ -106,9 +106,11 @@ namespace SteamAudio
             mTANDuration = serializedObject.FindProperty("TANDuration");
             mTANAmbisonicOrder = serializedObject.FindProperty("TANAmbisonicOrder");
             mTANMaxSources = serializedObject.FindProperty("TANMaxSources");
+
+            AlwaysShowSteamAudioToggle = true;
         }
 
-        public override void OnInspectorGUI()
+        protected override void OnSteamAudioGUI()
         {
             serializedObject.Update();
 

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioSourceInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioSourceInspector.cs
@@ -9,7 +9,7 @@ using UnityEditor;
 namespace SteamAudio
 {
     [CustomEditor(typeof(SteamAudioSource))]
-    public class SteamAudioSourceInspector : Editor
+    public class SteamAudioSourceInspector : SteamAudioEditor
     {
         SerializedProperty mDirectBinaural;
         SerializedProperty mInterpolation;
@@ -102,7 +102,7 @@ namespace SteamAudio
             mPathingMixLevel = serializedObject.FindProperty("pathingMixLevel");
         }
 
-        public override void OnInspectorGUI()
+        protected override void OnSteamAudioGUI()
         {
             var audioEngineIsUnity = (SteamAudioSettings.Singleton.audioEngine == AudioEngineType.Unity);
 

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioStaticMeshInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioStaticMeshInspector.cs
@@ -9,9 +9,8 @@ using UnityEditor;
 namespace SteamAudio
 {
     [CustomEditor(typeof(SteamAudioStaticMesh))]
-    public class SteamAudioStaticMeshInspector : Editor
+    public class SteamAudioStaticMeshInspector : SteamAudioEditor
     {
-#if STEAMAUDIO_ENABLED
         SerializedProperty mAsset;
         SerializedProperty mSceneNameWhenExported;
 
@@ -21,7 +20,7 @@ namespace SteamAudio
             mSceneNameWhenExported = serializedObject.FindProperty("sceneNameWhenExported");
         }
 
-        public override void OnInspectorGUI()
+        protected override void OnSteamAudioGUI()
         {
             serializedObject.Update();
 
@@ -54,11 +53,5 @@ namespace SteamAudio
 
             serializedObject.ApplyModifiedProperties();
         }
-#else
-        public override void OnInspectorGUI()
-        {
-            EditorGUILayout.HelpBox("Steam Audio is not supported for the target platform or STEAMAUDIO_ENABLED define symbol is missing.", MessageType.Warning);
-        }
-#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/AudioEngineAmbisonicSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/AudioEngineAmbisonicSource.cs
@@ -2,6 +2,7 @@
 // Copyright 2018 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
+#if UNITY_EDITOR || !STEAMAUDIO_DISABLED
 
 using UnityEngine;
 
@@ -33,3 +34,5 @@ namespace SteamAudio
         }
     }
 }
+
+#endif

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/AudioEngineSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/AudioEngineSource.cs
@@ -2,7 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
-#if STEAMAUDIO_ENABLED
+#if UNITY_EDITOR || !STEAMAUDIO_DISABLED
 
 using UnityEngine;
 

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/AudioEngineState.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/AudioEngineState.cs
@@ -2,7 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
-#if STEAMAUDIO_ENABLED
+#if UNITY_EDITOR || !STEAMAUDIO_DISABLED
 
 using System;
 using UnityEngine;

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/Baker.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/Baker.cs
@@ -2,7 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
-#if STEAMAUDIO_ENABLED
+#if UNITY_EDITOR || !STEAMAUDIO_DISABLED
 
 using AOT;
 using System;

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/FMODStudioAudioEngineSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/FMODStudioAudioEngineSource.cs
@@ -2,7 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
-#if STEAMAUDIO_ENABLED
+#if UNITY_EDITOR || !STEAMAUDIO_DISABLED
 
 using System;
 using System.Reflection;

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/FMODStudioAudioEngineState.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/FMODStudioAudioEngineState.cs
@@ -2,7 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
-#if STEAMAUDIO_ENABLED
+#if UNITY_EDITOR || !STEAMAUDIO_DISABLED
 
 using System;
 using System.Reflection;

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/InstancedMesh.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/InstancedMesh.cs
@@ -2,7 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
-#if STEAMAUDIO_ENABLED
+#if UNITY_EDITOR || !STEAMAUDIO_DISABLED
 
 using System;
 using UnityEngine;

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/ProbeBatch.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/ProbeBatch.cs
@@ -2,7 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
-#if STEAMAUDIO_ENABLED
+#if UNITY_EDITOR || !STEAMAUDIO_DISABLED
 
 using System;
 using UnityEngine;

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/Scene.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/Scene.cs
@@ -2,7 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
-#if STEAMAUDIO_ENABLED
+#if UNITY_EDITOR || !STEAMAUDIO_DISABLED
 
 using System;
 

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SerializedObject.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SerializedObject.cs
@@ -2,7 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
-#if STEAMAUDIO_ENABLED
+#if UNITY_EDITOR || !STEAMAUDIO_DISABLED
 
 using System;
 using System.Collections.Generic;

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/Simulator.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/Simulator.cs
@@ -2,7 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
-#if STEAMAUDIO_ENABLED
+#if UNITY_EDITOR || !STEAMAUDIO_DISABLED
 
 using System;
 using UnityEngine;

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/StaticMesh.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/StaticMesh.cs
@@ -2,7 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
-#if STEAMAUDIO_ENABLED
+#if UNITY_EDITOR || !STEAMAUDIO_DISABLED
 
 using System;
 using System.Runtime.InteropServices;

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioAmbisonicSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioAmbisonicSource.cs
@@ -17,6 +17,7 @@ namespace SteamAudio
 
         AudioEngineAmbisonicSource mAudioEngineAmbisonicSource = null;
 
+#if !STEAMAUDIO_DISABLED
         private void Awake()
         {
             mAudioEngineAmbisonicSource = AudioEngineAmbisonicSource.Create(SteamAudioSettings.Singleton.audioEngine);
@@ -58,6 +59,6 @@ namespace SteamAudio
                 mAudioEngineAmbisonicSource.UpdateParameters(this);
             }
         }
-
+#endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioBakedListener.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioBakedListener.cs
@@ -26,7 +26,7 @@ namespace SteamAudio
         [SerializeField]
         SteamAudioProbeBatch[] mProbeBatchesUsed = null;
 
-#if STEAMAUDIO_ENABLED
+#if UNITY_EDITOR || !STEAMAUDIO_DISABLED
         public int GetTotalDataSize()
         {
             return mTotalDataSize;

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioBakedSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioBakedSource.cs
@@ -26,7 +26,7 @@ namespace SteamAudio
         [SerializeField]
         SteamAudioProbeBatch[] mProbeBatchesUsed = null;
 
-#if STEAMAUDIO_ENABLED
+#if UNITY_EDITOR || !STEAMAUDIO_DISABLED
         public int GetTotalDataSize()
         {
             return mTotalDataSize;

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioDynamicObject.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioDynamicObject.cs
@@ -14,9 +14,10 @@ namespace SteamAudio
         [Header("Export Settings")]
         public SerializedData asset = null;
 
-#if STEAMAUDIO_ENABLED
+#if UNITY_EDITOR || !STEAMAUDIO_DISABLED
         InstancedMesh mInstancedMesh = null;
 
+#if !STEAMAUDIO_DISABLED
         private void OnDestroy()
         {
             SteamAudioManager.UnloadDynamicObject(this);
@@ -57,6 +58,8 @@ namespace SteamAudio
 
             mInstancedMesh.UpdateTransform(SteamAudioManager.CurrentScene, transform);
         }
+#endif
+
 #endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioGeometry.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioGeometry.cs
@@ -18,7 +18,7 @@ namespace SteamAudio
         [Range(0, 10)]
         public int terrainSimplificationLevel = 0;
 
-#if STEAMAUDIO_ENABLED
+#if UNITY_EDITOR || !STEAMAUDIO_DISABLED
         public int GetNumVertices()
         {
             if (exportAllChildren)

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioListener.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioListener.cs
@@ -37,50 +37,16 @@ namespace SteamAudio
         [SerializeField]
         SteamAudioProbeBatch[] mProbeBatchesUsed = null;
 
-#if STEAMAUDIO_ENABLED
+#if UNITY_EDITOR || !STEAMAUDIO_DISABLED
         Simulator mSimulator = null;
         Source mSource = null;
 
-        public int GetTotalDataSize()
-        {
-            return mTotalDataSize;
-        }
-
-        public int[] GetProbeDataSizes()
-        {
-            return mProbeDataSizes;
-        }
-
-        public int GetSizeForProbeBatch(int index)
-        {
-            return mProbeDataSizes[index];
-        }
-
-        public SteamAudioProbeBatch[] GetProbeBatchesUsed()
-        {
-            if (mProbeBatchesUsed == null)
-            {
-                CacheProbeBatchesUsed();
-            }
-
-            return mProbeBatchesUsed;
-        }
-
+#if !STEAMAUDIO_DISABLED
         private void Awake()
         {
             Reinitialize();
         }
-
-        public void Reinitialize()
-        {
-            mSimulator = SteamAudioManager.Simulator;
-
-            var settings = SteamAudioManager.GetSimulationSettings(false);
-            mSource = new Source(SteamAudioManager.Simulator, settings);
-
-            SteamAudioManager.GetAudioEngineState().SetReverbSource(mSource);
-        }
-
+        
         private void OnDestroy()
         {
             if (mSource != null)
@@ -116,6 +82,42 @@ namespace SteamAudio
 
         private void Update()
         {
+            SteamAudioManager.GetAudioEngineState().SetReverbSource(mSource);
+        }
+#endif
+
+        public int GetTotalDataSize()
+        {
+            return mTotalDataSize;
+        }
+
+        public int[] GetProbeDataSizes()
+        {
+            return mProbeDataSizes;
+        }
+
+        public int GetSizeForProbeBatch(int index)
+        {
+            return mProbeDataSizes[index];
+        }
+
+        public SteamAudioProbeBatch[] GetProbeBatchesUsed()
+        {
+            if (mProbeBatchesUsed == null)
+            {
+                CacheProbeBatchesUsed();
+            }
+
+            return mProbeBatchesUsed;
+        }
+
+        public void Reinitialize()
+        {
+            mSimulator = SteamAudioManager.Simulator;
+
+            var settings = SteamAudioManager.GetSimulationSettings(false);
+            mSource = new Source(SteamAudioManager.Simulator, settings);
+
             SteamAudioManager.GetAudioEngineState().SetReverbSource(mSource);
         }
 

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioManager.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioManager.cs
@@ -35,7 +35,7 @@ namespace SteamAudio
         [Header("HRTF Settings")]
         public int currentHRTF = 0;
 
-#if STEAMAUDIO_ENABLED
+#if UNITY_EDITOR || !STEAMAUDIO_DISABLED
         public string[] hrtfNames = null;
 
         int mNumCPUCores = 0;
@@ -463,7 +463,7 @@ namespace SteamAudio
             }
         }
 
-#if STEAMAUDIO_ENABLED
+#if !STEAMAUDIO_DISABLED
         private void LateUpdate()
         {
             if (mAudioEngineState == null)
@@ -1478,6 +1478,7 @@ namespace SteamAudio
             occluded = (byte)((numHits > 0) ? 1 : 0);
         }
 
+#if !STEAMAUDIO_DISABLED
         // This method is called as soon as scripts are loaded, which happens whenever play mode is started
         // (in the editor), or whenever the game is launched. We then create a Steam Audio Manager object
         // and move it to the Don't Destroy On Load list.
@@ -1486,6 +1487,7 @@ namespace SteamAudio
         {
             Initialize(ManagerInitReason.Playing);
         }
+#endif
 
         // Exports the static geometry in a scene.
         public static void ExportScene(UnityEngine.SceneManagement.Scene unityScene, bool exportOBJ)

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioProbeBatch.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioProbeBatch.cs
@@ -38,36 +38,12 @@ namespace SteamAudio
         [SerializeField] Sphere[] mProbeSpheres = null;
         [SerializeField] List<BakedDataLayerInfo> mBakedDataLayerInfo = new List<BakedDataLayerInfo>();
 
-#if STEAMAUDIO_ENABLED
+#if UNITY_EDITOR || !STEAMAUDIO_DISABLED
         ProbeBatch mProbeBatch = null;
 
         const float kProbeDrawSize = 0.1f;
-
-        public SerializedData GetAsset()
-        {
-            if (asset == null)
-            {
-                asset = SerializedData.PromptForNewAsset(gameObject.scene.name + "_" + name);
-            }
-
-            return asset;
-        }
-
-        public int GetNumProbes()
-        { 
-            return (mProbeSpheres == null) ? 0 : mProbeSpheres.Length; 
-        }
-
-        public int GetNumLayers()
-        {
-            return mBakedDataLayerInfo.Count;
-        }
-
-        public IntPtr GetProbeBatch()
-        {
-            return mProbeBatch.Get();
-        }
-
+        
+#if !STEAMAUDIO_DISABLED
         private void Awake()
         {
             if (asset == null)
@@ -96,6 +72,32 @@ namespace SteamAudio
             {
                 SteamAudioManager.Simulator.RemoveProbeBatch(mProbeBatch);
             }
+        }
+#endif
+
+        public SerializedData GetAsset()
+        {
+            if (asset == null)
+            {
+                asset = SerializedData.PromptForNewAsset(gameObject.scene.name + "_" + name);
+            }
+
+            return asset;
+        }
+
+        public int GetNumProbes()
+        { 
+            return (mProbeSpheres == null) ? 0 : mProbeSpheres.Length; 
+        }
+
+        public int GetNumLayers()
+        {
+            return mBakedDataLayerInfo.Count;
+        }
+
+        public IntPtr GetProbeBatch()
+        {
+            return mProbeBatch.Get();
         }
 
         void OnDrawGizmosSelected()

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioSource.cs
@@ -140,7 +140,7 @@ namespace SteamAudio
         [Range(0.0f, 10.0f)]
         public float pathingMixLevel = 1.0f;
 
-#if STEAMAUDIO_ENABLED
+#if UNITY_EDITOR || !STEAMAUDIO_DISABLED
         Simulator mSimulator = null;
         Source mSource = null;
         AudioEngineSource mAudioEngineSource = null;
@@ -153,6 +153,7 @@ namespace SteamAudio
         DistanceAttenuationModel mCurveAttenuationModel = new DistanceAttenuationModel { };
         GCHandle mThis;
 
+#if !STEAMAUDIO_DISABLED
         private void Awake()
         {
             mSimulator = SteamAudioManager.Simulator;
@@ -238,6 +239,7 @@ namespace SteamAudio
                 mAudioEngineSource.UpdateParameters(this);
             }
         }
+#endif
 
         private void OnDrawGizmosSelected()
         {

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioStaticMesh.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioStaticMesh.cs
@@ -13,9 +13,10 @@ namespace SteamAudio
         public SerializedData asset = null;
         public string sceneNameWhenExported = "";
 
-#if STEAMAUDIO_ENABLED
+#if UNITY_EDITOR || !STEAMAUDIO_DISABLED
         StaticMesh mStaticMesh = null;
 
+#if !STEAMAUDIO_DISABLED
         void Start()
         {
             if (asset == null)
@@ -61,6 +62,8 @@ namespace SteamAudio
                 }
             }
         }
+#endif
+
 #endif
     }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/UnityAudioEngineSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/UnityAudioEngineSource.cs
@@ -2,7 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
-#if STEAMAUDIO_ENABLED
+#if UNITY_EDITOR || !STEAMAUDIO_DISABLED
 
 using System;
 using UnityEngine;

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/UnityAudioEngineState.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/UnityAudioEngineState.cs
@@ -2,7 +2,7 @@
 // Copyright 2017 Valve Corporation. All rights reserved. Subject to the following license:
 // https://valvesoftware.github.io/steam-audio/license.html
 //
-#if STEAMAUDIO_ENABLED
+#if UNITY_EDITOR || !STEAMAUDIO_DISABLED
 
 using System;
 using UnityEngine;


### PR DESCRIPTION
This is the implementation of an idea proposed here: https://github.com/ValveSoftware/steam-audio/issues/282#issuecomment-1782196709 which is a follow up to https://github.com/ValveSoftware/steam-audio/pull/280

The basic idea is to drop automatic scripting symbol defines in favor of warning messages and tools to toggle Steam Audio on and off.

Implementation details:

- Flipped the define symbol from ~`STEAMAUDIO_ENABLED`~ to `STEAMAUDIO_DISABLED`
- Added prompt messages in Steam Audio component inspectors to notify user Steam Audio's status and/or warning messages about native plugins' availability. This is impletment with a new `SteamAudioEditor` base class
- Implemented a plugin lookup routine to detect native plugin availability. This may cover the case when user build their own binary and imported them (which currently seems unlikely) or the case where Valve is able to provide console binaries through a console partnership program
- Now Steam Audio code will always be available in Unity Editor to enable editing and baking even when a unsupported target is selected, and Steam Audio will still dry run in Play Mode if disabled. More specifically:
  - Data classes are wrapped with `#if UNITY_EDITOR || !STEAMAUDIO_DISABLED`
  - Unity components excluding any seriailzied field is also wrapped with `#if UNITY_EDITOR || !STEAMAUDIO_DISABLED`
  - Unity life-cycle hooks are wrapped with an additional `!STEAMAUDIO_DISABLED` to force Steam Audio to dry run in Editor if  a unsupported target is selected

Finally a screenshot for good measure:

<img width="345" alt="image" src="https://github.com/ValveSoftware/steam-audio/assets/3797859/dec07c77-b356-4f7f-93d8-eecf36dc7f79">