### PR TITLE
[Unity] Performance improvement on SteamAudioManager.GetPerspectiveCorrection

### DIFF
--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioManager.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioManager.cs
@@ -193,9 +193,14 @@ namespace SteamAudio
             return reflectionEffectType;
         }
 
-        public static PerspectiveCorrection GetPerspectiveCorrection()
+        public static PerspectiveCorrection GetPerspectiveCorrection() 
         {
-            PerspectiveCorrection correction;
+            if (!SteamAudioSettings.Singleton.perspectiveCorrection) 
+            {
+                return default;
+            }
+
+            PerspectiveCorrection correction = default;
             if (Camera.main != null && Camera.main.aspect > .0f)
             {
                 correction.enabled = SteamAudioSettings.Singleton.perspectiveCorrection ? Bool.True : Bool.False;
@@ -204,13 +209,6 @@ namespace SteamAudio
 
                 // Camera space matches OpenGL convention. No need to transform matrix to ConvertTransform.
                 correction.transform = Common.TransformMatrix(Camera.main.projectionMatrix * Camera.main.worldToCameraMatrix);
-            }
-            else
-            {
-                correction.enabled = Bool.False;
-                correction.xfactor = 1.0f;
-                correction.yfactor = 1.0f;
-                correction.transform = Common.TransformMatrix(UnityEngine.Matrix4x4.identity);
             }
 
             return correction;

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioManager.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioManager.cs
@@ -67,6 +67,7 @@ namespace SteamAudio
         bool mSimulationCompleted = false;
         float mSimulationUpdateTimeElapsed = 0.0f;
         bool mSceneCommitRequired = false;
+        Camera mainCamera;
 
         static SteamAudioManager sSingleton = null;
 

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioManager.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioManager.cs
@@ -193,25 +193,28 @@ namespace SteamAudio
             return reflectionEffectType;
         }
 
-        public static PerspectiveCorrection GetPerspectiveCorrection() 
-        {
-            if (!SteamAudioSettings.Singleton.perspectiveCorrection) 
-            {
+        public static PerspectiveCorrection GetPerspectiveCorrection() {
+            if (!SteamAudioSettings.Singleton.perspectiveCorrection) {
                 return default;
             }
 
+            var mainCamera = Singleton.GetMainCamera();
             PerspectiveCorrection correction = default;
-            if (Camera.main != null && Camera.main.aspect > .0f)
+            if (mainCamera != null && mainCamera.aspect > .0f)
             {
                 correction.enabled = SteamAudioSettings.Singleton.perspectiveCorrection ? Bool.True : Bool.False;
                 correction.xfactor = 1.0f * SteamAudioSettings.Singleton.perspectiveCorrectionFactor;
-                correction.yfactor = correction.xfactor / Camera.main.aspect;
+                correction.yfactor = correction.xfactor / mainCamera.aspect;
 
                 // Camera space matches OpenGL convention. No need to transform matrix to ConvertTransform.
-                correction.transform = Common.TransformMatrix(Camera.main.projectionMatrix * Camera.main.worldToCameraMatrix);
+                correction.transform = Common.TransformMatrix(mainCamera.projectionMatrix * mainCamera.worldToCameraMatrix);
             }
 
             return correction;
+        }
+
+        public Camera GetMainCamera() {
+            return mainCamera != null ? mainCamera : (mainCamera = Camera.main);
         }
 
         public static SimulationSettings GetSimulationSettings(bool baking)


### PR DESCRIPTION
## The problem
the method [GetPerspectiveCorrection()](https://github.com/Chrisdbhr/steam-audio/blob/v4.5.0/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioManager.cs#L196) in [SteamAudioManager](https://github.com/Chrisdbhr/steam-audio/blob/v4.5.0/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioManager.cs) is called every [LateUpdate()](https://docs.unity3d.com/ScriptReference/MonoBehaviour.LateUpdate.html) even when perspectiveCorrection is disabled in [SteamAudioSettings](https://github.com/Chrisdbhr/steam-audio/blob/v4.5.0/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioSettings.cs) and inside it there are multiple calls to [Camera.main](https://docs.unity3d.com/ScriptReference/Camera-main.html), this method searches for the first game object with the "MainCamera" tag, with can lead to performance issues on scenes with a lot of game objects, as shown bellow.
 
![image](https://github.com/ValveSoftware/steam-audio/assets/19819051/3b6e7c57-d0e6-4007-b43d-298e5f4ba7eb)

## Solution implemented
- Do not search for camera when [SteamAudioSettings.perspectiveCorrection](https://github.com/Chrisdbhr/steam-audio/blob/55e1517461efaa97012d2551ec78b4ffe53b98d4/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioSettings.cs#L26) is set to false, returning default values for the struct [PerspectiveCorrection](https://github.com/Chrisdbhr/steam-audio/blob/v4.5.0/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudio.cs#L644)
- Cache the reference to the **MainCamera** when first found.