### PR TITLE
docs: rename "PC" platform to "Windows"

### DIFF
--- a/index.html
+++ b/index.html
@@ -331,7 +331,7 @@
     <div class="row app-marketing-grid" style="color:#000;">
       <div class="col-md-2 offset-md-1 px-2 mb-5">
         <img class="mb-1" src="assets/img/icon_windows.png">
-        <h6 class="text-uppercase" style="font-weight:bold; margin-top: 2em; margin-bottom: 2em; color:#000;">PC</h6>
+        <h6 class="text-uppercase" style="font-weight:bold; margin-top: 2em; margin-bottom: 2em; color:#000;">Windows</h6>
       </div>
       <div class="col-md-2 px-2 mb-5">
         <img class="mb-1" src="assets/img/icon_osx.png">


### PR DESCRIPTION
Windows shouldn't be called "PC" on the project's website, because Linux is run on "PCs", too.

![image](https://github.com/ValveSoftware/steam-audio/assets/467294/e9cbf1f2-6504-406f-b8e5-4e668b2ac265)
