### PR TITLE
Use IPLuint8 instead of uint8_t in phonon.h

### DIFF
--- a/core/src/core/phonon.h
+++ b/core/src/core/phonon.h
@@ -1389,7 +1389,7 @@ typedef struct {
 
     /** Pointer to a buffer containing SOFA file data from which to load HRTF data. Either \c sofaFileName
         or \c sofaData should be non-NULL. Only for \c IPL_HRTFTYPE_SOFA. */
-    const uint8_t* sofaData;
+    const IPLuint8* sofaData;
 
     /** Size (in bytes) of the buffer pointed to by \c sofaData. Only for \c IPL_HRTFTYPE_SOFA. */
     int sofaDataSize;


### PR DESCRIPTION
Follow-up to #308

`uint8_t*` is used in `IPLHRTFSettings::sofaData` which requires `stdint.h` to be included. This is unnecessary because there's already an unsigned 8 bit type defined: `IPLuint8`

This PR changes the use of `uint8_t` to `IPLuint8*`.