### PR TITLE
EnterPlayMode Options fix

### DIFF
--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioManager.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioManager.cs
@@ -439,7 +439,8 @@ namespace SteamAudio
 
 #if UNITY_EDITOR && UNITY_2019_3_OR_NEWER
                 // If the developer has disabled scene reload, SceneManager.sceneLoaded won't fire during initial load
-                if (EditorSettings.enterPlayModeOptions.HasFlag(EnterPlayModeOptions.DisableSceneReload))
+                if ( EditorSettings.enterPlayModeOptionsEnabled &&
+                    EditorSettings.enterPlayModeOptions.HasFlag(EnterPlayModeOptions.DisableSceneReload))
                 {
                     OnSceneLoaded(SceneManager.GetActiveScene(), LoadSceneMode.Single);
                 }


### PR DESCRIPTION
Hello,

we found an issue in the unity integration of steam audio that is due to how unity handles the enterplaymode options.

Current flow evaluates the condition that checks the SceneReload to true in all cases, thus considering that the SceneReload is always disabled, even if the project has the default settings ("Enter playmode Options unticked, thus always reload domain and scene).

This is due to the fact that unity write DisableDomainReload and DisableSceneReload flags by default, and requires to first check if the project has the setting "Enter Playmode Options" ticked before considering the flag values.

You can find the fix attached to this pull request.

Thanks for releasing the project as open source !