### PR TITLE
Add support for AVX on Linux

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -88,7 +88,7 @@ if (IPL_OS_WINDOWS AND IPL_CPU_X64)
     option(STEAMAUDIO_BUILD_DOCS "Build documentation." ON)
 endif()
 
-if (IPL_OS_WINDOWS AND (IPL_CPU_X86 OR IPL_CPU_X64))
+if ((IPL_OS_WINDOWS OR IPL_OS_LINUX) AND (IPL_CPU_X86 OR IPL_CPU_X64))
     option(STEAMAUDIO_ENABLE_AVX "Enable AVX intrinsics." ON)
 endif()
 

--- a/core/src/core/CMakeLists.txt
+++ b/core/src/core/CMakeLists.txt
@@ -505,13 +505,15 @@ if (STEAMAUDIO_ENABLE_AVX)
         float8_delay.cpp
         float8_reverb_effect.cpp
     )
-    set_source_files_properties(
-        float8_iir.cpp
-        float8_delay.cpp
-        float8_reverb_effect.cpp
-        PROPERTIES
-            COMPILE_FLAGS "/arch:AVX"
-    )
+	if (IPL_OS_WINDOWS)
+        set_source_files_properties(
+            float8_iir.cpp
+            float8_delay.cpp
+            float8_reverb_effect.cpp
+            PROPERTIES
+                COMPILE_FLAGS "/arch:AVX"
+        )
+	endif()
 endif()
 
 if (STEAMAUDIO_ENABLE_EMBREE)

--- a/core/src/core/avx_float8.h
+++ b/core/src/core/avx_float8.h
@@ -30,53 +30,53 @@ typedef __m256 float8_t;
 
 namespace float8
 {
-    inline float8_t add(float8_t a,
+    inline IPL_FLOAT8_ATTR float8_t add(float8_t a,
                         float8_t b)
     {
         return _mm256_add_ps(a, b);
     }
 
-    inline float8_t sub(float8_t a,
+    inline IPL_FLOAT8_ATTR float8_t sub(float8_t a,
                         float8_t b)
     {
         return _mm256_sub_ps(a, b);
     }
 
-    inline float8_t mul(float8_t a,
+    inline IPL_FLOAT8_ATTR float8_t mul(float8_t a,
                         float8_t b)
     {
         return _mm256_mul_ps(a, b);
     }
 
-    inline float8_t div(float8_t a,
+    inline IPL_FLOAT8_ATTR float8_t div(float8_t a,
                         float8_t b)
     {
         return _mm256_div_ps(a, b);
     }
 
-    inline float8_t load(const float* p)
+    inline IPL_FLOAT8_ATTR float8_t load(const float* p)
     {
         return _mm256_load_ps(p);
     }
 
-    inline float8_t loadu(const float* p)
+    inline IPL_FLOAT8_ATTR float8_t loadu(const float* p)
     {
         return _mm256_loadu_ps(p);
     }
 
-    inline void store(float* p,
+    inline IPL_FLOAT8_ATTR void store(float* p,
                       float8_t x)
     {
         return _mm256_store_ps(p, x);
     }
 
-    inline void storeu(float* p,
+    inline IPL_FLOAT8_ATTR void storeu(float* p,
                        float8_t x)
     {
         return _mm256_storeu_ps(p, x);
     }
 
-    inline float8_t set(float x0,
+    inline IPL_FLOAT8_ATTR float8_t set(float x0,
                         float x1,
                         float x2,
                         float x3,
@@ -88,43 +88,43 @@ namespace float8
         return _mm256_set_ps(x7, x6, x5, x4, x3, x2, x1, x0);
     }
 
-    inline float8_t set1(float x)
+    inline IPL_FLOAT8_ATTR float8_t set1(float x)
     {
         return _mm256_set1_ps(x);
     }
 
-    inline float8_t set1(const float* x)
+    inline IPL_FLOAT8_ATTR float8_t set1(const float* x)
     {
         return _mm256_broadcast_ss(x);
     }
 
-    inline float8_t zero()
+    inline IPL_FLOAT8_ATTR float8_t zero()
     {
         return _mm256_setzero_ps();
     }
 
-    inline float get1(float8_t x)
+    inline IPL_FLOAT8_ATTR float get1(float8_t x)
     {
         return _mm_cvtss_f32(_mm256_castps256_ps128(x));
     }
 
     template <int N>
-    inline float8_t replicateHalves(float8_t x)
+    inline IPL_FLOAT8_ATTR float8_t replicateHalves(float8_t x)
     {
         return _mm256_shuffle_ps(x, x, _MM_SHUFFLE(N, N, N, N));
     }
 
-    inline float8_t replicateLower(float8_t x)
+    inline IPL_FLOAT8_ATTR float8_t replicateLower(float8_t x)
     {
         return _mm256_permute2f128_ps(x, x, 0x00);
     }
 
-    inline float8_t replicateUpper(float8_t x)
+    inline IPL_FLOAT8_ATTR float8_t replicateUpper(float8_t x)
     {
         return _mm256_permute2f128_ps(x, x, 0x11);
     }
 
-    inline void avoidTransitionPenalty()
+    inline IPL_FLOAT8_ATTR void avoidTransitionPenalty()
     {
         _mm256_zeroupper();
     }

--- a/core/src/core/delay.h
+++ b/core/src/core/delay.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #if defined(IPL_ENABLE_FLOAT8)
-#include <immintrin.h>
+#include "float8.h"
 #endif
 
 #include "array.h"
@@ -49,7 +49,7 @@ public:
     void get(float4_t& out);
 
 #if defined(IPL_ENABLE_FLOAT8)
-    void get(float8_t& out);
+    void IPL_FLOAT8_ATTR get(float8_t& out);
 #endif
 
     void get(int numSamples,
@@ -58,7 +58,7 @@ public:
     void put(float4_t in);
 
 #if defined(IPL_ENABLE_FLOAT8)
-    void put(float8_t in);
+    void IPL_FLOAT8_ATTR put(float8_t in);
 #endif
 
     void put(int numSamples,

--- a/core/src/core/float8.h
+++ b/core/src/core/float8.h
@@ -24,6 +24,12 @@
 // float8
 // --------------------------------------------------------------------------------------------------------------------
 
+#if ( defined(__clang__) || defined(__GNUC__) ) && ( defined(IPL_CPU_X86) || defined(IPL_CPU_X64) )
+#define IPL_FLOAT8_ATTR __attribute__((target("avx")))
+#else
+#define IPL_FLOAT8_ATTR
+#endif
+
 #if defined(IPL_CPU_X86) || defined(IPL_CPU_X64)
 #include "avx_float8.h"
 #endif

--- a/core/src/core/float8_delay.cpp
+++ b/core/src/core/float8_delay.cpp
@@ -25,7 +25,7 @@ namespace ipl {
 // Delay
 // --------------------------------------------------------------------------------------------------------------------
 
-void Delay::get(float8_t& out)
+void IPL_FLOAT8_ATTR Delay::get(float8_t& out)
 {
     if (mReadCursor + 7 < static_cast<int>(mRingBuffer.size(0)))
     {
@@ -57,7 +57,7 @@ void Delay::get(float8_t& out)
     }
 }
 
-void Delay::put(float8_t in)
+void IPL_FLOAT8_ATTR Delay::put(float8_t in)
 {
     if (mCursor + 7 < static_cast<int>(mRingBuffer.size(0)))
     {

--- a/core/src/core/float8_iir.cpp
+++ b/core/src/core/float8_iir.cpp
@@ -33,7 +33,7 @@ void IIRFilterer::resetFilter_float8()
     memset(mCoeffs8, 0, 8 * 12 * sizeof(float));
 }
 
-void IIRFilterer::setFilter_float8(const IIR& filter)
+void IPL_FLOAT8_ATTR IIRFilterer::setFilter_float8(const IIR& filter)
 {
     mFilter = filter;
 
@@ -86,7 +86,7 @@ void IIRFilterer::setFilter_float8(const IIR& filter)
     }
 }
 
-float8_t IIRFilterer::apply(float8_t in)
+float8_t IPL_FLOAT8_ATTR IIRFilterer::apply(float8_t in)
 {
     auto coeffxp7 = float8::load(&mCoeffs8[0][0]);
     auto coeffxp6 = float8::load(&mCoeffs8[1][0]);
@@ -150,7 +150,7 @@ float8_t IIRFilterer::apply(float8_t in)
     return y;
 }
 
-void IIRFilterer::apply_float8(int size,
+void IPL_FLOAT8_ATTR IIRFilterer::apply_float8(int size,
                                const float* in,
                                float* out)
 {

--- a/core/src/core/float8_reverb_effect.cpp
+++ b/core/src/core/float8_reverb_effect.cpp
@@ -27,7 +27,7 @@ namespace ipl {
 // ReverbEffect
 // --------------------------------------------------------------------------------------------------------------------
 
-void ReverbEffect::apply_float8(const float* reverbTimes,
+void IPL_FLOAT8_ATTR ReverbEffect::apply_float8(const float* reverbTimes,
                                 const float* in,
                                 float* out)
 {
@@ -142,7 +142,7 @@ void ReverbEffect::apply_float8(const float* reverbTimes,
     float8::avoidTransitionPenalty();
 }
 
-void ReverbEffect::tail_float8(float* out)
+void IPL_FLOAT8_ATTR ReverbEffect::tail_float8(float* out)
 {
     for (auto i = 0; i < kNumDelays; ++i)
     {
@@ -211,7 +211,7 @@ void ReverbEffect::tail_float8(float* out)
     float8::avoidTransitionPenalty();
 }
 
-void ReverbEffect::multiplyHadamardMatrix(const float8_t* in,
+void IPL_FLOAT8_ATTR ReverbEffect::multiplyHadamardMatrix(const float8_t* in,
                                           float8_t* out)
 {
     out[0]  = in[0] + in[1] + in[2] + in[3] + in[4] + in[5] + in[6] + in[7] + in[8] + in[9] + in[10] + in[11] + in[12] + in[13] + in[14] + in[15];

--- a/core/src/core/iir.h
+++ b/core/src/core/iir.h
@@ -109,7 +109,7 @@ public:
 
 #if defined(IPL_ENABLE_FLOAT8)
     // Applies the filter to 8 samples of input, using SIMD operations.
-    float8_t apply(float8_t in);
+    float8_t IPL_FLOAT8_ATTR apply(float8_t in);
 #endif
 
     // Applies the filter to an entire buffer of input, using SIMD operations.
@@ -137,9 +137,9 @@ private:
     void apply_float4(int size, const float* in, float* out);
 
 #if defined(IPL_ENABLE_FLOAT8)
-    void resetFilter_float8();
-    void setFilter_float8(const IIR& filter);
-    void apply_float8(int size, const float* in, float* out);
+    void IPL_FLOAT8_ATTR resetFilter_float8();
+    void IPL_FLOAT8_ATTR setFilter_float8(const IIR& filter);
+    void IPL_FLOAT8_ATTR apply_float8(int size, const float* in, float* out);
 #endif
 };
 

--- a/core/src/core/reverb_effect.h
+++ b/core/src/core/reverb_effect.h
@@ -101,7 +101,7 @@ private:
                                        float4_t* out);
 
 #if defined(IPL_ENABLE_FLOAT8)
-    static void multiplyHadamardMatrix(const float8_t* in,
+    static void IPL_FLOAT8_ATTR multiplyHadamardMatrix(const float8_t* in,
                                        float8_t* out);
 #endif
 


### PR DESCRIPTION
Allows IPL_ENABLE_FLOAT8 to work on Linux. Uses `__attribute__((target("avx)))` to avoid enabling `-mavx` globally.

I've only tested this on Linux in a limited capacity so far