### PR TITLE
Fix get_dependencies.py failing to build flatbuffers (tested on macOS)

### DIFF
--- a/core/build/dependencies.json
+++ b/core/build/dependencies.json
@@ -22,10 +22,8 @@
                 {
                     "platforms": ["osx"],
                     "flags": [
-                        "-DCMAKE_C_FLAGS=-Wno-error=unused-but-set-variable",
-                        "-DCMAKE_CXX_FLAGS=-Wno-error=unused-but-set-variable",
-                        "-DCMAKE_C_FLAGS=-Wno-unknown-warning-option",
-                        "-DCMAKE_CXX_FLAGS=-Wno-unknown-warning-option"
+                        "-DCMAKE_C_FLAGS=-Wno-error=unused-but-set-variable -Wno-unknown-warning-option",
+                        "-DCMAKE_CXX_FLAGS=-Wno-error=unused-but-set-variable -Wno-unknown-warning-option"
                     ]
                 }
             ]


### PR DESCRIPTION
Due to a -Wunused-but-set-variable warning (and -Werror) in flatbuffers/src/flatbuffers/src/idl_gen_rust.cpp:409

get_dependencies.py is apparently aware of the issue but DCMAKE_C[XX]_FLAGS are defined twice in dependencies.json for flatbuffers, the second time apparently overriding the first.