### PR TITLE
Fix incorrect validation

### DIFF
--- a/core/src/core/api_validation_layer.cpp
+++ b/core/src/core/api_validation_layer.cpp
@@ -528,7 +528,7 @@ std::string to_string(T* value)
     VALIDATE_POINTER(value); \
     if (value) { \
         VALIDATE_IPLDirectEffectFlags(value->flags); \
-        VALIDATE_IPLTransmissionType(value->flags); \
+        VALIDATE_IPLTransmissionType(value->transmissionType); \
         VALIDATE(IPLfloat32, value->distanceAttenuation, (0.0f <= value->distanceAttenuation && value->distanceAttenuation <= 1.0f)); \
         for (int iBand = 0; iBand < 3; ++iBand) { \
             VALIDATE(IPLfloat32, value->airAbsorption[iBand], (0.0f <= value->airAbsorption[iBand] && value->airAbsorption[iBand] <= 1.0f)); \


### PR DESCRIPTION
Fixes warning: comparison of different enumeration types ('IPLDirectEffectFlags' and 'IPLTransmissionType') [-Wenum-compare] 

Detected on Xcode 15.2