### PR TITLE
Fix Broken DipoleWeight Validation

### DIFF
--- a/core/src/core/api_validation_layer.cpp
+++ b/core/src/core/api_validation_layer.cpp
@@ -806,7 +806,7 @@ std::string to_string(T* value)
 #define VALIDATE_IPLDirectivity(value) { \
     VALIDATE_POINTER(value); \
     if (value) { \
-        VALIDATE(IPLfloat32, value->dipoleWeight, (0.0f <= value->dipoleWeight && 1.0f <= value->dipoleWeight)); \
+        VALIDATE(IPLfloat32, value->dipoleWeight, (0.0f <= value->dipoleWeight && value->dipoleWeight <= 1.0f)); \
         VALIDATE(IPLfloat32, value->dipolePower, (value->dipolePower >= 0.0f)); \
     } \
 }


### PR DESCRIPTION
```
VALIDATE(IPLfloat32, value->dipoleWeight, (0.0f <= value->dipoleWeight && 1.0f <= value->dipoleWeight)); \
``` 

is intended to ensure the value is between 0 & 1, but as is, it is testing if the value is greater than or equal to 0 & also greater than or equal to 1. 