### PR TITLE
Don't link delayimp on UWP because it doesn't exist there

### DIFF
--- a/core/src/core/CMakeLists.txt
+++ b/core/src/core/CMakeLists.txt
@@ -584,7 +584,7 @@ endif()
 # This is needed so we can include generated headers
 target_include_directories(core PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
-if (IPL_OS_WINDOWS)
+if (IPL_OS_WINDOWS AND NOT (CMAKE_SYSTEM_NAME MATCHES "WindowsStore"))
     target_link_libraries(core PUBLIC delayimp)
 elseif (IPL_OS_LINUX)
     target_link_libraries(core PUBLIC m dl pthread)


### PR DESCRIPTION
`delayimp.lib` does not exist on UWP, but SteamAudio always tries to link it on Windows platforms. This PR prevents SteamAudio from linking `delayimp.lib` on UWP. SteamAudio still works on UWP without it. 