### PR TITLE
Fixed Crash because component owner can be invalid.

### DIFF
--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioSpatialization.cpp
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioSpatialization.cpp
@@ -339,7 +339,7 @@ void FSteamAudioSpatializationPlugin::ProcessAudio(const FAudioPluginSourceInput
         // FIXME: Unreal 4.27 does not pass the audio component id correctly to the spatializer plugin. It does this
         // correctly for the occlusion and reverb plugins.
         UAudioComponent* AudioComponent = UAudioComponent::GetAudioComponentFromID(InputData.AudioComponentId);
-        USteamAudioSourceComponent* SteamAudioSourceComponent = (AudioComponent) ? AudioComponent->GetOwner()->FindComponentByClass<USteamAudioSourceComponent>() : nullptr;
+        USteamAudioSourceComponent* SteamAudioSourceComponent = AudioComponent && AudioComponent->GetOwner() ? AudioComponent->GetOwner()->FindComponentByClass<USteamAudioSourceComponent>() : nullptr;
 
         if (SteamAudioSourceComponent && FSteamAudioModule::IsPlaying())
         {


### PR DESCRIPTION
It was possible to crash the editor because the SteamAudioSourceComponent had no valid owner. So I added a check for it.