### PR TITLE
[Unity] Fix editor crash when cancelling the export OBJ dialog

### DIFF
--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioManager.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioManager.cs
@@ -1260,6 +1260,12 @@ namespace SteamAudio
             var dataAsset = (!exportOBJ) ? GetDataAsset(dynamicObject) : null;
             var objFileName = (exportOBJ) ? GetOBJFileName(dynamicObject) : "";
 
+            if (!exportOBJ && dataAsset == null)
+                return;
+
+            if (exportOBJ && (objFileName == null || objFileName.Length == 0))
+                return;
+
             Export(objects, dynamicObject.name, dataAsset, objFileName, true, exportOBJ);
         }
 


### PR DESCRIPTION
Selecting "Export Dynamic Object as OBJ" in the Dynamic Object settings in the unity plugin and immediately cancelling the file dialog will crash the editor. Unity returns an empty string if the file dialog is cancelled, which steam audio then tries exporting to which causes undefined behaviour.

This PR simply adds checks to see if the directory is invalid and returns early.

It may also be worth adding checks on the C++ side, currently there are no checks on the file pointers returned by `utf8fopen` on line 291 & 294 of `scene.cpp` which seems to be the root cause of this issue.