### PR TITLE
Fixing operator re-definiton for clang

### DIFF
--- a/core/src/core/float4.h
+++ b/core/src/core/float4.h
@@ -41,7 +41,8 @@ namespace float4
 
 }
 
-#if defined(IPL_OS_WINDOWS)
+// Clang already defines operators for __m128
+#if defined(IPL_OS_WINDOWS) && !defined(__clang__)
 
 namespace ipl {
 


### PR DESCRIPTION
I had to make this change to compile with llvm for windows