### PR TITLE
[Unity] Replace obsoleted Unity API calls

### DIFF
--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioBakedListener.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioBakedListener.cs
@@ -154,5 +154,5 @@ namespace SteamAudio
 #endif
         }
 #endif
-        }
+    }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioBakedListener.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioBakedListener.cs
@@ -124,7 +124,11 @@ namespace SteamAudio
             tasks[0].component = this;
             tasks[0].name = gameObject.name;
             tasks[0].identifier = mIdentifier;
+#if UNITY_2020_3_OR_NEWER
+            tasks[0].probeBatches = (useAllProbeBatches) ? FindObjectsByType<SteamAudioProbeBatch>(FindObjectsSortMode.None) : probeBatches;
+#else
             tasks[0].probeBatches = (useAllProbeBatches) ? FindObjectsOfType<SteamAudioProbeBatch>() : probeBatches;
+#endif
             tasks[0].probeBatchNames = new string[tasks[0].probeBatches.Length];
             tasks[0].probeBatchAssets = new SerializedData[tasks[0].probeBatches.Length];
             for (var i = 0; i < tasks[0].probeBatchNames.Length; ++i)
@@ -143,8 +147,12 @@ namespace SteamAudio
 
         void CacheProbeBatchesUsed()
         {
+#if UNITY_2020_3_OR_NEWER
+            mProbeBatchesUsed = (useAllProbeBatches) ? FindObjectsByType<SteamAudioProbeBatch>(FindObjectsSortMode.None) : probeBatches;
+#else
             mProbeBatchesUsed = (useAllProbeBatches) ? FindObjectsOfType<SteamAudioProbeBatch>() : probeBatches;
+#endif
         }
 #endif
-    }
+        }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioBakedSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioBakedSource.cs
@@ -124,7 +124,11 @@ namespace SteamAudio
             tasks[0].component = this;
             tasks[0].name = gameObject.name;
             tasks[0].identifier = mIdentifier;
-            tasks[0].probeBatches = (useAllProbeBatches) ? FindObjectsOfType<SteamAudioProbeBatch>() : probeBatches;
+#if UNITY_2020_3_OR_NEWER
+            tasks[0].probeBatches = (useAllProbeBatches) ? FindObjectsByType<SteamAudioProbeBatch>(FindObjectsSortMode.None) : probeBatches;
+#else
+            tasks[0].probeBatches = (useAllProbeBatches) ?  FindObjectsOfType<SteamAudioProbeBatch>() : probeBatches;
+#endif
             tasks[0].probeBatchNames = new string[tasks[0].probeBatches.Length];
             tasks[0].probeBatchAssets = new SerializedData[tasks[0].probeBatches.Length];
             for (var i = 0; i < tasks[0].probeBatchNames.Length; ++i)
@@ -143,8 +147,12 @@ namespace SteamAudio
 
         void CacheProbeBatchesUsed()
         {
+#if UNITY_2020_3_OR_NEWER
+            mProbeBatchesUsed = (useAllProbeBatches) ? FindObjectsByType<SteamAudioProbeBatch>(FindObjectsSortMode.None) : probeBatches;
+#else
             mProbeBatchesUsed = (useAllProbeBatches) ? FindObjectsOfType<SteamAudioProbeBatch>() : probeBatches;
+#endif
         }
 #endif
-    }
+        }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioBakedSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioBakedSource.cs
@@ -154,5 +154,5 @@ namespace SteamAudio
 #endif
         }
 #endif
-        }
+    }
 }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/UnityAudioEngineState.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/UnityAudioEngineState.cs
@@ -62,7 +62,11 @@ namespace SteamAudio
     {
         public override Transform GetListenerTransform()
         {
+#if UNITY_2023_3_OR_NEWER
+            var audioListener = GameObject.FindFirstObjectByType<AudioListener>();
+#else
             var audioListener = GameObject.FindObjectOfType<AudioListener>();
+#endif
             return (audioListener != null) ? audioListener.transform : null;
         }
 


### PR DESCRIPTION
A simple patch to address compiler warnings generated in recent versions of Unity.

The Unity API has marked some methods that are being called by the Steam Audio Unity plugin as obsolete. The following method calls have been changed in this pull request:

- `UnityEngine.Object`: `FindObjectOfType<T>()` replaced with `FindFirstObjectByType<T>()`
- `UnityEngine.Object`: `FindObjectsOfType<T>()` replaced with `FindObjectsByType<T>(FindObjectsSortMode)`

These new methods have been implemented since Unity 2020.3, and the old methods have been marked as obsolete since 2023.1

To ensure compatibility of the Unity plugin remains the same as before (2017.3+), these call changes have been wrapped in `#if UNITY_2020_3_OR-NEWER` preprocessor directives.

This is my first pull request for this repo, let me know if I need to make any changes.