### PR TITLE
Fix std::chrono by include chrono

### DIFF
--- a/core/src/core/profiler.h
+++ b/core/src/core/profiler.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "memory_allocator.h"
+#include <chrono>
 
 namespace ipl {
 


### PR DESCRIPTION
Hello, I am the maintainer of vcpkg. 

Due to the adjustment of `STL` methods, after the PR: https://github.com/microsoft/STL/pull/5105 the call to `std::chrono` needs to explicitly include the header file `chrono`. 

I have submitted a PR in vcpkg to adapt.
https://github.com/microsoft/vcpkg/pull/43670

Error:
```
D:\b\steam-audio\src\ba4a490a67-27c1a63d4c.clean\core\src\core\profiler.h(40): error C2039: 'high_resolution_clock': is not a member of 'std::chrono'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.42.34433\include\__msvc_chrono.hpp(286): note: see declaration of 'std::chrono'
D:\b\steam-audio\src\ba4a490a67-27c1a63d4c.clean\core\src\core\profiler.h(40): error C2065: 'high_resolution_clock': undeclared identifier
D:\b\steam-audio\src\ba4a490a67-27c1a63d4c.clean\core\src\core\profiler.h(40): error C2923: 'std::chrono::time_point': 'high_resolution_clock' is not a valid template type argument for parameter '_Clock'
D:\b\steam-audio\src\ba4a490a67-27c1a63d4c.clean\core\src\core\profiler.h(40): note: see declaration of 'high_resolution_clock'
D:\b\steam-audio\src\ba4a490a67-27c1a63d4c.clean\core\src\core\profiler.h(40): error C2976: 'std::chrono::time_point': too few template arguments
```