### PR TITLE
adding a null check to destroy in UnityAudioEngineSource.cs

### DIFF
--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/UnityAudioEngineSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/UnityAudioEngineSource.cs
@@ -40,6 +40,12 @@ namespace SteamAudio
         public override void Destroy()
         {
             var index = 28;
+
+            if (mAudioSource != null)
+            {
+                mAudioSource.SetSpatializerFloat(index, -1);
+            }
+            
             mAudioSource.SetSpatializerFloat(index, -1);
 
             if (mSteamAudioSource)

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/UnityAudioEngineSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/UnityAudioEngineSource.cs
@@ -45,8 +45,6 @@ namespace SteamAudio
             {
                 mAudioSource.SetSpatializerFloat(index, -1);
             }
-            
-            mAudioSource.SetSpatializerFloat(index, -1);
 
             if (mSteamAudioSource)
             {


### PR DESCRIPTION
 mAudioSource can be nuked before the Steam Audio component. 
This handles that and allows Steam Audio to remove the source.

I would also add a debug logerror and potentially reorder this to do the Steam Audio remove source first. 

The fact that UpdateParameters checks this, but on destroy does not make me believe this was missed.