### PR TITLE
Define DSP parameters in steamaudio_fmod.h

### DIFF
--- a/fmod/doc/api-reference.rst
+++ b/fmod/doc/api-reference.rst
@@ -15,6 +15,6 @@ Functions
 DSP Parameters
 ^^^^^^^^^^^^^^
 
-.. doxygenenum:: SteamAudioFMOD::SpatializeEffect::Params
-.. doxygenenum:: SteamAudioFMOD::ReverbEffect::Params
-.. doxygenenum:: SteamAudioFMOD::MixerReturnEffect::Params
+.. doxygenenum:: IPL_SPATIALIZE_PARAMS
+.. doxygenenum:: IPL_REVERB_PARAMS
+.. doxygenenum:: IPL_MIXRETURN_PARAMS

--- a/fmod/include/phonon/phonon.h
+++ b/fmod/include/phonon/phonon.h
@@ -3742,12 +3742,16 @@ IPLAPI void IPLCALL iplSourceRelease(IPLSource* source);
 
 /** Adds a source to the set of sources processed by a simulator in subsequent simulations.
 
+    Call \c iplSimulatorCommit after calling this function for the changes to take effect.
+
     \param  simulator   The simulator being used.
     \param  source      The source to add.
 */
 IPLAPI void IPLCALL iplSourceAdd(IPLSource source, IPLSimulator simulator);
 
 /** Removes a source from the set of sources processed by a simulator in subsequent simulations.
+
+    Call \c iplSimulatorCommit after calling this function for the changes to take effect.
 
     \param  simulator   The simulator being used.
     \param  source      The source to remove.

--- a/fmod/src/mix_return_effect.cpp
+++ b/fmod/src/mix_return_effect.cpp
@@ -20,54 +20,26 @@ namespace SteamAudioFMOD {
 
 namespace MixerReturnEffect {
 
-/**
- *  DSP parameters for the "Steam Audio Mixer Return" effect.
- */
-enum Params
-{
-    /**
-     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_BOOL`
-     *
-     *  If true, applies HRTF-based 3D audio rendering to mixed reflected sound. Results in an improvement in
-     *  spatialization quality, at the cost of slightly increased CPU usage.
-     */
-    BINAURAL,
 
-    /**
-     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_INT`
-     *
-     *  **Range**: 0 to 2.
-     *
-     *  Controls the output format.
-     *
-     *  - `0`: Output will be the format in FMOD's mixer.
-     *  - `1`: Output will be the format from FMOD's final output.
-     *  - `2`: Output will be the format from the event's input.
-     */
-    OUTPUT_FORMAT,
-
-    /** The number of parameters in this effect. */
-    NUM_PARAMS
-};
 
 FMOD_DSP_PARAMETER_DESC gParams[] = {
     { FMOD_DSP_PARAMETER_TYPE_BOOL, "Binaural", "", "Spatialize reflected sound using HRTF." },
     { FMOD_DSP_PARAMETER_TYPE_INT, "OutputFormat", "", "Output Format" },
 };
 
-FMOD_DSP_PARAMETER_DESC* gParamsArray[NUM_PARAMS];
+FMOD_DSP_PARAMETER_DESC* gParamsArray[IPL_MIXRETURN_NUM_PARAMS];
 
 const char* gOutputFormatValues[] = { "From Mixer", "From Final Out", "From Input" };
 
 void initParamDescs()
 {
-    for (auto i = 0; i < NUM_PARAMS; ++i)
+    for (auto i = 0; i < IPL_MIXRETURN_NUM_PARAMS; ++i)
     {
         gParamsArray[i] = &gParams[i];
     }
 
-    gParams[BINAURAL].booldesc = {false};
-    gParams[OUTPUT_FORMAT].intdesc = { 0, 2, 0, false, gOutputFormatValues };
+    gParams[IPL_MIXRETURN_BINAURAL].booldesc = {false};
+    gParams[IPL_MIXRETURN_OUTPUT_FORMAT].intdesc = { 0, 2, 0, false, gOutputFormatValues };
 }
 
 struct State
@@ -250,7 +222,7 @@ FMOD_RESULT F_CALL getBool(FMOD_DSP_STATE* state,
 
     switch (index)
     {
-    case BINAURAL:
+    case IPL_MIXRETURN_BINAURAL:
         *value = effect->binaural;
         break;
     default:
@@ -269,7 +241,7 @@ FMOD_RESULT F_CALL getInt(FMOD_DSP_STATE* state,
 
     switch (index)
     {
-    case OUTPUT_FORMAT:
+    case IPL_MIXRETURN_OUTPUT_FORMAT:
         *value = static_cast<int>(effect->outputFormat);
         break;
     default:
@@ -287,7 +259,7 @@ FMOD_RESULT F_CALL setBool(FMOD_DSP_STATE* state,
 
     switch (index)
     {
-    case BINAURAL:
+    case IPL_MIXRETURN_BINAURAL:
         effect->binaural = value;
         break;
     default:
@@ -305,7 +277,7 @@ FMOD_RESULT F_CALL setInt(FMOD_DSP_STATE* state,
 
     switch (index)
     {
-    case OUTPUT_FORMAT:
+    case IPL_MIXRETURN_OUTPUT_FORMAT:
         effect->outputFormat = static_cast<ParameterSpeakerFormatType>(value);
         break;
     default:
@@ -404,7 +376,7 @@ FMOD_DSP_DESCRIPTION gMixerReturnEffect
     nullptr,
     MixerReturnEffect::process,
     nullptr,
-    MixerReturnEffect::NUM_PARAMS,
+    IPL_MIXRETURN_NUM_PARAMS,
     MixerReturnEffect::gParamsArray,
     nullptr,
     MixerReturnEffect::setInt,

--- a/fmod/src/reverb_effect.cpp
+++ b/fmod/src/reverb_effect.cpp
@@ -20,53 +20,24 @@ namespace SteamAudioFMOD {
 
 namespace ReverbEffect {
 
-/**
- *  DSP parameters for the "Steam Audio Reverb" effect.
- */
-enum Params
-{
-    /**
-     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_BOOL`
-     *
-     *  If true, applies HRTF-based 3D audio rendering to reverb. Results in an improvement in spatialization quality
-     *  when using convolution or hybrid reverb, at the cost of slightly increased CPU usage.
-     */
-    BINAURAL,
-
-    /**
-     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_INT`
-     *
-     *  **Range**: 0 to 2.
-     *
-     *  Controls the output format.
-     *
-     *  - `0`: Output will be the format in FMOD's mixer.
-     *  - `1`: Output will be the format from FMOD's final output.
-     *  - `2`: Output will be the format from the event's input.
-     */
-    OUTPUT_FORMAT,
-
-    /** The number of parameters in this effect. */
-    NUM_PARAMS
-};
 
 FMOD_DSP_PARAMETER_DESC gParams[] = {
     { FMOD_DSP_PARAMETER_TYPE_BOOL, "Binaural", "", "Spatialize reflected sound using HRTF." },
     { FMOD_DSP_PARAMETER_TYPE_INT, "OutputFormat", "", "Output Format" },
 };
 
-FMOD_DSP_PARAMETER_DESC* gParamsArray[NUM_PARAMS];
+FMOD_DSP_PARAMETER_DESC* gParamsArray[IPL_REVERB_NUM_PARAMS];
 const char* gOutputFormatValues[] = { "From Mixer", "From Final Out", "From Input" };
 
 void initParamDescs()
 {
-    for (auto i = 0; i < NUM_PARAMS; ++i)
+    for (auto i = 0; i < IPL_REVERB_NUM_PARAMS; ++i)
     {
         gParamsArray[i] = &gParams[i];
     }
 
-    gParams[BINAURAL].booldesc = {false};
-    gParams[OUTPUT_FORMAT].intdesc = { 0, 2, 0, false, gOutputFormatValues };
+    gParams[IPL_REVERB_BINAURAL].booldesc = {false};
+    gParams[IPL_REVERB_OUTPUT_FORMAT].intdesc = { 0, 2, 0, false, gOutputFormatValues };
 }
 
 struct State
@@ -251,7 +222,7 @@ FMOD_RESULT F_CALL getBool(FMOD_DSP_STATE* state,
 
     switch (index)
     {
-    case BINAURAL:
+    case IPL_REVERB_BINAURAL:
         *value = effect->binaural;
         break;
     default:
@@ -269,7 +240,7 @@ FMOD_RESULT F_CALL setBool(FMOD_DSP_STATE* state,
 
     switch (index)
     {
-    case BINAURAL:
+    case IPL_REVERB_BINAURAL:
         effect->binaural = value;
         break;
     default:
@@ -288,7 +259,7 @@ FMOD_RESULT F_CALL getInt(FMOD_DSP_STATE* state,
 
     switch (index)
     {
-    case OUTPUT_FORMAT:
+    case IPL_REVERB_OUTPUT_FORMAT:
         *value = static_cast<int>(effect->outputFormat);
         break;
     default:
@@ -306,7 +277,7 @@ FMOD_RESULT F_CALL setInt(FMOD_DSP_STATE* state,
 
     switch (index)
     {
-    case OUTPUT_FORMAT:
+    case IPL_REVERB_OUTPUT_FORMAT:
         effect->outputFormat = static_cast<ParameterSpeakerFormatType>(value);
         break;
     default:
@@ -432,7 +403,7 @@ FMOD_DSP_DESCRIPTION gReverbEffect
     nullptr,
     ReverbEffect::process,
     nullptr,
-    ReverbEffect::NUM_PARAMS,
+    IPL_REVERB_NUM_PARAMS,
     ReverbEffect::gParamsArray,
     nullptr,
     ReverbEffect::setInt,

--- a/fmod/src/steamaudio_fmod.h
+++ b/fmod/src/steamaudio_fmod.h
@@ -189,6 +189,430 @@ private:
 
 extern "C" {
 
+/**
+ *  DSP parameters for the "Steam Audio Spatializer" effect.
+*/
+typedef enum IPL_SPATIALIZE_PARAMS
+{
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_DATA`
+     *
+     *  World-space position of the source. Automatically written by FMOD Studio.
+     */
+    IPL_SPATIALIZE_SOURCE_POSITION,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_DATA`
+     *
+     *  Overall linear gain of this effect. Automatically read by FMOD Studio.
+     */
+    IPL_SPATIALIZE_OVERALL_GAIN,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_INT`
+     *
+     *  **Range**: 0 to 2.
+     *
+     *  How to render distance attenuation.
+     *
+     *  -   `0`: Don't render distance attenuation.
+     *  -   `1`: Use a distance attenuation value calculated using the default physics-based model.
+     *  -   `2`: Use a distance attenuation value calculated using the curve specified in the FMOD Studio UI.
+     */
+    IPL_SPATIALIZE_APPLY_DISTANCEATTENUATION,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_INT`
+     *
+     *  **Range**: 0 to 2.
+     *
+     *  How to render air absorption.
+     *
+     *  -   `0`: Don't render air absorption.
+     *  -   `1`: Use air absorption values calculated using the default exponential decay model.
+     *  -   `2`: Use air absorption values specified in the \c AIRABSORPTION_LOW, \c AIRABSORPTION_MID, and
+     *           \c AIRABSORPTION_HIGH parameters.
+     */
+    IPL_SPATIALIZE_APPLY_AIRABSORPTION,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_INT`
+     *
+     *  **Range**: 0 to 2.
+     *
+     *  How to render directivity.
+     *
+     *  -   `0`: Don't render directivity.
+     *  -   `1`: Use a directivity value calculated using the default dipole model, driven by the
+     *           \c DIRECTIVITY_DIPOLEWEIGHT and \c DIRECTIVITY_DIPOLEPOWER parameters.
+     *  -   `2`: Use the directivity value specified in the \c DIRECTIVITY parameter.
+     */
+    IPL_SPATIALIZE_APPLY_DIRECTIVITY,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_INT`
+     *
+     *  **Range**: 0 to 2.
+     *
+     *  How to render occlusion.
+     *
+     *  -   `0`: Don't render occlusion.
+     *  -   `1`: Use the occlusion value calculated by the game engine using simulation, and provided via the
+     *           \c SIMULATION_OUTPUTS parameter.
+     *  -   `2`: Use the occlusion value specified in the \c OCCLUSION parameter.
+     */
+    IPL_SPATIALIZE_APPLY_OCCLUSION,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_INT`
+     *
+     *  **Range**: 0 to 2.
+     *
+     *  How to render transmission.
+     *
+     *  -   `0`: Don't render transmission.
+     *  -   `1`: Use the transmission values calculated by the game engine using simulation, and provided via the
+     *           \c SIMULATION_OUTPUTS parameter.
+     *  -   `2`: Use the transmission values specified in the \c TRANSMISSION_LOW, \c TRANSMISSION_MID, and
+     *           \c TRANSMISSION_HIGH parameters.
+     */
+    IPL_SPATIALIZE_APPLY_TRANSMISSION,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_BOOL`
+     *
+     *  If true, reflections are rendered, using the data calculated by the game engine using simulation, and provided
+     *  via the \c SIMULATION_OUTPUTS parameter.
+     */
+    IPL_SPATIALIZE_APPLY_REFLECTIONS,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_BOOL`
+     *
+     *  If true, pathing is rendered, using the data calculated by the game engine using simulation, and provided
+     *  via the \c SIMULATION_OUTPUTS parameter.
+     */
+    IPL_SPATIALIZE_APPLY_PATHING,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_INT`
+     *
+     *  **Range**: 0 to 1.
+     *
+     *  Controls how HRTFs are interpolated when the source moves relative to the listener.
+     *
+     *  - `0`: Nearest-neighbor interpolation.
+     *  - `1`: Bilinear interpolation.
+     */
+    IPL_SPATIALIZE_HRTF_INTERPOLATION,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_FLOAT`
+     *
+     *  Not currently used.
+     */
+    IPL_SPATIALIZE_DISTANCEATTENUATION,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_INT`
+     *
+     *  **Range**: 0 to 4.
+     *
+     *  Type of distance attenuation curve preset to use when \c APPLY_DISTANCEATTENUATION is \c 1.
+     *
+     *  - `0`: Linear squared rolloff.
+     *  - `1`: Linear rolloff.
+     *  - `2`: Inverse rolloff.
+     *  - `3`: Inverse squared rolloff.
+     *  - `4`: Custom rolloff.
+     */
+    IPL_SPATIALIZE_DISTANCEATTENUATION_ROLLOFFTYPE,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_FLOAT`
+     *
+     *  **Range**: 0 to 10000.
+     *
+     *  Minimum distance value for the distance attenuation curve.
+     */
+    IPL_SPATIALIZE_DISTANCEATTENUATION_MINDISTANCE,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_FLOAT`
+     *
+     *  **Range**: 0 to 10000.
+     *
+     *  Maximum distance value for the distance attenuation curve.
+     */
+    IPL_SPATIALIZE_DISTANCEATTENUATION_MAXDISTANCE,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_FLOAT`
+     *
+     *  **Range**: 0 to 1.
+     *
+     *  The low frequency (up to 800 Hz) EQ value for air absorption. Only used if \c APPLY_AIRABSORPTION is set to
+     *  \c 2. 0 = low frequencies are completely attenuated, 1 = low frequencies are not attenuated at all.
+     */
+    IPL_SPATIALIZE_AIRABSORPTION_LOW,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_FLOAT`
+     *
+     *  **Range**: 0 to 1.
+     *
+     *  The middle frequency (800 Hz - 8 kHz) EQ value for air absorption. Only used if \c APPLY_AIRABSORPTION is set
+     *  to \c 2. 0 = middle frequencies are completely attenuated, 1 = middle frequencies are not attenuated at all.
+     */
+    IPL_SPATIALIZE_AIRABSORPTION_MID,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_FLOAT`
+     *
+     *  **Range**: 0 to 1.
+     *
+     *  The high frequency (8 kHz and above) EQ value for air absorption. Only used if \c APPLY_AIRABSORPTION is set to
+     *  \c 2. 0 = high frequencies are completely attenuated, 1 = high frequencies are not attenuated at all.
+     */
+    IPL_SPATIALIZE_AIRABSORPTION_HIGH,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_FLOAT`
+     *
+     *  **Range**: 0 to 1.
+     *
+     *  The directivity attenuation value. Only used if \c APPLY_DIRECTIVITY is set to \c 2. 0 = sound is completely
+     *  attenuated, 1 = sound is not attenuated at all.
+     */
+    IPL_SPATIALIZE_DIRECTIVITY,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_FLOAT`
+     *
+     *  **Range**: 0 to 1.
+     *
+     *  Blends between monopole (omnidirectional) and dipole directivity patterns. 0 = pure monopole (sound is emitted
+     *  in all directions with equal intensity), 1 = pure dipole (sound is focused to the front and back of the source).
+     *  At 0.5, the source has a cardioid directivity, with most of the sound emitted to the front of the source. Only
+     *  used if \c APPLY_DIRECTIVITY is set to \c 1.
+     */
+    IPL_SPATIALIZE_DIRECTIVITY_DIPOLEWEIGHT,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_FLOAT`
+     *
+     *  **Range**: 0 to 4.
+     *
+     *  Controls how focused the dipole directivity is. Higher values result in sharper directivity patterns. Only used
+     *  if \c APPLY_DIRECTIVITY is set to \c 1.
+     */
+    IPL_SPATIALIZE_DIRECTIVITY_DIPOLEPOWER,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_FLOAT`
+     *
+     *  **Range**: 0 to 1.
+     *
+     *  The occlusion attenuation value. Only used if \c APPLY_OCCLUSION is set to \c 2. 0 = sound is completely
+     *  attenuated, 1 = sound is not attenuated at all.
+     */
+    IPL_SPATIALIZE_OCCLUSION,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_INT`
+     *
+     *  **Range**: 0 to 1.
+     *
+     *  Specifies how the transmission filter is applied.
+     *
+     * - `0`: Transmission is modeled as a single attenuation factor.
+     * - `1`: Transmission is modeled as a 3-band EQ.
+     */
+    IPL_SPATIALIZE_TRANSMISSION_TYPE,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_FLOAT`
+     *
+     *  **Range**: 0 to 1.
+     *
+     *  The low frequency (up to 800 Hz) EQ value for transmission. Only used if \c APPLY_TRANSMISSION is set to \c 2.
+     *  0 = low frequencies are completely attenuated, 1 = low frequencies are not attenuated at all.
+     */
+    IPL_SPATIALIZE_TRANSMISSION_LOW,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_FLOAT`
+     *
+     *  **Range**: 0 to 1.
+     *
+     *  The middle frequency (800 Hz to 8 kHz) EQ value for transmission. Only used if \c APPLY_TRANSMISSION is set to
+     *  \c 2. 0 = middle frequencies are completely attenuated, 1 = middle frequencies are not attenuated at all.
+     */
+    IPL_SPATIALIZE_TRANSMISSION_MID,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_FLOAT`
+     *
+     *  **Range**: 0 to 1.
+     *
+     *  The high frequency (8 kHz and above) EQ value for transmission. Only used if \c APPLY_TRANSMISSION is set to
+     *  \c 2. 0 = high frequencies are completely attenuated, 1 = high frequencies are not attenuated at all.
+     */
+    IPL_SPATIALIZE_TRANSMISSION_HIGH,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_FLOAT`
+     *
+     *  **Range**: 0 to 1.
+     *
+     *  The contribution of the direct sound path to the overall mix for this event. Lower values reduce the
+     *  contribution more.
+     */
+    IPL_SPATIALIZE_DIRECT_MIXLEVEL,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_BOOL`
+     *
+     *  If true, applies HRTF-based 3D audio rendering to reflections. Results in an improvement in spatialization
+     *  quality when using convolution or hybrid reverb, at the cost of slightly increased CPU usage.
+     */
+    IPL_SPATIALIZE_REFLECTIONS_BINAURAL,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_FLOAT`
+     *
+     *  **Range**: 0 to 10.
+     *
+     *  The contribution of reflections to the overall mix for this event. Lower values reduce the contribution more.
+     */
+    IPL_SPATIALIZE_REFLECTIONS_MIXLEVEL,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_BOOL`
+     *
+     *  If true, applies HRTF-based 3D audio rendering to pathing. Results in an improvement in spatialization
+     *  quality, at the cost of slightly increased CPU usage.
+     */
+    IPL_SPATIALIZE_PATHING_BINAURAL,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_FLOAT`
+     *
+     *  **Range**: 0 to 10.
+     *
+     *  The contribution of pathing to the overall mix for this event. Lower values reduce the contribution more.
+     */
+    IPL_SPATIALIZE_PATHING_MIXLEVEL,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_DATA`
+     *
+     *  **DEPRECATED**
+     *
+     *  Pointer to the `IPLSimulationOutputs` structure containing simulation results.
+     */
+    IPL_SPATIALIZE_SIMULATION_OUTPUTS,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_BOOL`
+     *
+     *  If true, applies HRTF-based 3D audio rendering to the direct sound path. Otherwise, sound is panned based on
+     *  the speaker configuration.
+     */
+    IPL_SPATIALIZE_DIRECT_BINAURAL,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_DATA`
+     *
+     *  (FMOD Studio 2.02+) The event's min/max distance range. Automatically set by FMOD Studio.
+     */
+    IPL_SPATIALIZE_DISTANCE_ATTENUATION_RANGE,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_INT`
+     *
+     *  Handle of the `IPLSource` object to use for obtaining simulation results. The handle can
+     *  be obtained by calling `iplFMODAddSource`.
+     */
+    IPL_SPATIALIZE_SIMULATION_OUTPUTS_HANDLE,
+    
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_INT`
+     *
+     *  **Range**: 0 to 2.
+     *
+     *  Controls the output format.
+     *
+     *  - `0`: Output will be the format in FMOD's mixer.
+     *  - `1`: Output will be the format from FMOD's final output.
+     *  - `2`: Output will be the format from the event's input.
+     */
+    IPL_SPATIALIZE_OUTPUT_FORMAT,
+
+    /** The number of parameters in this effect. */
+    IPL_SPATIALIZE_NUM_PARAMS
+} IPL_SPATIALIZE_PARAMS;
+
+/**
+ *  DSP parameters for the "Steam Audio Reverb" effect.
+ */
+typedef enum IPL_REVERB_PARAMS
+{
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_BOOL`
+     *
+     *  If true, applies HRTF-based 3D audio rendering to reverb. Results in an improvement in spatialization quality
+     *  when using convolution or hybrid reverb, at the cost of slightly increased CPU usage.
+     */
+    IPL_REVERB_BINAURAL,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_INT`
+     *
+     *  **Range**: 0 to 2.
+     *
+     *  Controls the output format.
+     *
+     *  - `0`: Output will be the format in FMOD's mixer.
+     *  - `1`: Output will be the format from FMOD's final output.
+     *  - `2`: Output will be the format from the event's input.
+     */
+    IPL_REVERB_OUTPUT_FORMAT,
+
+    /** The number of parameters in this effect. */
+    IPL_REVERB_NUM_PARAMS
+} IPL_REVERB_PARAMS;
+
+/**
+ *  DSP parameters for the "Steam Audio Mixer Return" effect.
+ */
+typedef enum IPL_MIXRETURN_PARAMS
+{
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_BOOL`
+     *
+     *  If true, applies HRTF-based 3D audio rendering to mixed reflected sound. Results in an improvement in
+     *  spatialization quality, at the cost of slightly increased CPU usage.
+     */
+    IPL_MIXRETURN_BINAURAL,
+
+    /**
+     *  **Type**: `FMOD_DSP_PARAMETER_TYPE_INT`
+     *
+     *  **Range**: 0 to 2.
+     *
+     *  Controls the output format.
+     *
+     *  - `0`: Output will be the format in FMOD's mixer.
+     *  - `1`: Output will be the format from FMOD's final output.
+     *  - `2`: Output will be the format from the event's input.
+     */
+    IPL_MIXRETURN_OUTPUT_FORMAT,
+
+    /** The number of parameters in this effect. */
+    IPL_MIXRETURN_NUM_PARAMS
+} IPL_MIXRETURN_PARAMS;
+
 // This function is called by FMOD Studio when it loads plugins. It returns metadata that describes all of the
 // effects implemented in this DLL.
 F_EXPORT FMOD_PLUGINLIST* F_CALL FMODGetPluginDescriptionList();


### PR DESCRIPTION
Fully fixes #432 

https://github.com/ValveSoftware/steam-audio/commit/cc661206e341241a2814606c1dbb2957c93119df was a partial fix that didn't fix the root issue, which is that `SteamAudioFMOD::SpatializeEffect::Params`, `SteamAudioFMOD::ReverbEffect::Params`, and `SteamAudioFMOD::MixerReturnEffect::Params` aren't defined in a header anywhere

I moved those enums into `steamaudio_fmod.h` in a C-compatible way so tools like [bindgen](https://github.com/rust-lang/rust-bindgen) can understand them