### PR TITLE
[Unreal] Fix Adding Reverb Submix to the steam audio settings crash

### DIFF
--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioReverb.cpp
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioReverb.cpp
@@ -532,6 +532,11 @@ void FSteamAudioReverbSubmixPlugin::LazyInit()
         Context = iplContextRetain(SteamAudio::FSteamAudioModule::GetManager().GetContext());
     }
 
+    if (!ReverbPlugin)
+    {
+        ReverbPlugin = StaticCast<SteamAudio::FSteamAudioReverbPlugin*>(GEngine->GetAudioDeviceManager()->GetMainAudioDeviceRaw()->ReverbPluginInterface.Get());
+    }
+
     IPLAudioSettings AudioSettings = ReverbPlugin->GetAudioSettings();
 
     if (!HRTF)


### PR DESCRIPTION
When adding Reverb Submix to the Steam Audio settings, if the game starts, the engine crashes. This happens because the `ReverbPlugin` pointer is nullptr. This PR completely fixes this crash.

This problem was also described in issue #405 by @ViniCortez
Also, this problem (looking at Crash Dump) was encountered in #364 

### Media

Video demonstrating the crash:

https://github.com/user-attachments/assets/e6f2e6de-8361-4ef8-8755-e8d851a01b0a