### PR TITLE
[Unreal] Add nullptr check for OpenCL device

### DIFF
--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioManager.cpp
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioManager.cpp
@@ -705,7 +705,8 @@ void FSteamAudioManager::Tick(float DeltaTime)
 
         ThreadPoolIdle = false;
 
-        AsyncPool(*ThreadPool, [this]
+        if (OpenCLDevice)
+        AsyncPool(*ThreadPool, [this] // May cause a crash when OpenCL device is not initialized
         {
             iplSimulatorRunReflections(Simulator);
             iplSimulatorRunPathing(Simulator);

--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioManager.cpp
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioManager.cpp
@@ -213,7 +213,7 @@ bool FSteamAudioManager::InitializeSteamAudio(EManagerInitReason Reason)
     bool bShouldInitEmbree = (Reason == EManagerInitReason::BAKING || Reason == EManagerInitReason::PLAYING) && (ConfiguredSceneType == IPL_SCENETYPE_EMBREE);
     bool bShouldInitRadeonRays = (Reason == EManagerInitReason::BAKING || Reason == EManagerInitReason::PLAYING) && (ConfiguredSceneType == IPL_SCENETYPE_RADEONRAYS);
     bool bShouldInitTrueAudioNext = (Reason == EManagerInitReason::PLAYING) && (ConfiguredReflectionEffectType == IPL_REFLECTIONEFFECTTYPE_TAN);
-    bool bShouldInitOpenCL = (bShouldInitRadeonRays || bShouldInitTrueAudioNext);
+    bShouldInitOpenCL = (bShouldInitRadeonRays || bShouldInitTrueAudioNext);
 
     if (bShouldInitEmbree)
     {
@@ -705,7 +705,7 @@ void FSteamAudioManager::Tick(float DeltaTime)
 
         ThreadPoolIdle = false;
 
-        if (OpenCLDevice)
+        if (!bShouldInitOpenCL || (bShouldInitOpenCL && OpenCLDevice))
         AsyncPool(*ThreadPool, [this] // May cause a crash when OpenCL device is not initialized
         {
             iplSimulatorRunReflections(Simulator);

--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioManager.h
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioManager.h
@@ -138,6 +138,9 @@ public:
     void RemoveListener(USteamAudioListenerComponent* Listener);
 
 private:
+    /** a cached value indicating whether OpenCL should be initialized */
+    bool bShouldInitOpenCL = false;
+
     /** The scene type we were actually able to initialize. */
     IPLSceneType ActualSceneType;
 

--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioManager.h
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioManager.h
@@ -144,6 +144,9 @@ public:
     void RemoveListener(USteamAudioListenerComponent* Listener);
 
 private:
+    /** a cached value indicating whether OpenCL should be initialized */
+    bool bShouldInitOpenCL = false;
+
     /** If equal false, then Steam Audio plugins do not affect the sound */
     bool bIsSteamAudioEnabled = true;
 


### PR DESCRIPTION
Without this nullptr check, using TrueAudio Next with not initializing the OpenCL device causes the `AsyncPool()` function to crash.