### PR TITLE
[Unreal] Add the ability to map physical materials to Steam Audio Materials

### DIFF
--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioSettings.cpp
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioSettings.cpp
@@ -79,8 +79,6 @@ FSteamAudioSettings USteamAudioSettings::GetSettings() const
     Settings.DefaultMeshMaterial = GetMaterialForAsset(DefaultMeshMaterial);
     Settings.DefaultLandscapeMaterial = GetMaterialForAsset(DefaultLandscapeMaterial);
     Settings.DefaultBSPMaterial = GetMaterialForAsset(DefaultBSPMaterial);
-    Settings.bNeedToSetupDefaultMaterial = bNeedToSetupDefaultMaterial;
-    Settings.DefaultAudioGeometryMaterial = GetMaterialForAsset(DefaultAudioGeometryMaterial);
     Settings.PhysMatToSteamAudioMatTable = const_cast<PhysMatToSteamAudioMatTableType*>(&PhysMatToSteamAudioMatTable);
     Settings.SceneType = static_cast<IPLSceneType>(SceneType);
     Settings.MaxOcclusionSamples = MaxOcclusionSamples;

--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioSettings.cpp
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioSettings.cpp
@@ -79,6 +79,9 @@ FSteamAudioSettings USteamAudioSettings::GetSettings() const
     Settings.DefaultMeshMaterial = GetMaterialForAsset(DefaultMeshMaterial);
     Settings.DefaultLandscapeMaterial = GetMaterialForAsset(DefaultLandscapeMaterial);
     Settings.DefaultBSPMaterial = GetMaterialForAsset(DefaultBSPMaterial);
+    Settings.bNeedToSetupDefaultMaterial = bNeedToSetupDefaultMaterial;
+    Settings.DefaultAudioGeometryMaterial = GetMaterialForAsset(DefaultAudioGeometryMaterial);
+    Settings.PhysMatToSteamAudioMatTable = const_cast<PhysMatToSteamAudioMatTableType*>(&PhysMatToSteamAudioMatTable);
     Settings.SceneType = static_cast<IPLSceneType>(SceneType);
     Settings.MaxOcclusionSamples = MaxOcclusionSamples;
     Settings.RealTimeRays = RealTimeRays;

--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Public/SteamAudioSettings.h
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Public/SteamAudioSettings.h
@@ -85,6 +85,18 @@ enum class EHRTFNormType : uint8
 
 class USOFAFile;
 
+USTRUCT(BlueprintType)
+struct FPhysMatToSteamAudioMatTable_Value
+{
+    GENERATED_USTRUCT_BODY()
+
+public:
+    UPROPERTY(EditAnywhere, meta = (AllowedClasses = "/Script/SteamAudio.SteamAudioMaterial"))
+    FSoftObjectPath SteamAudioMaterial;
+};
+
+using PhysMatToSteamAudioMatTableType = TMap<FSoftObjectPath, FPhysMatToSteamAudioMatTable_Value>;
+
 /**
  * Used to store a copy of the current Steam Audio settings upon initialization, with Unreal plugin types replaced by
  * their corresponding Steam Audio API types.
@@ -97,6 +109,9 @@ struct FSteamAudioSettings
     IPLMaterial DefaultMeshMaterial;
     IPLMaterial DefaultLandscapeMaterial;
     IPLMaterial DefaultBSPMaterial;
+    bool bNeedToSetupDefaultMaterial;
+    IPLMaterial DefaultAudioGeometryMaterial;
+    PhysMatToSteamAudioMatTableType* PhysMatToSteamAudioMatTable;
     IPLSceneType SceneType;
     int MaxOcclusionSamples;
     int RealTimeRays;
@@ -175,6 +190,15 @@ public:
     /** Reference to the Steam Audio Material asset to use as the default material for BSP geometry. */
     UPROPERTY(GlobalConfig, EditAnywhere, Category = SceneExportSettings, meta = (AllowedClasses = "/Script/SteamAudio.SteamAudioMaterial", DisplayName = "Default BSP Material"))
     FSoftObjectPath DefaultBSPMaterial;
+
+    UPROPERTY(GlobalConfig, EditAnywhere, Category = SteamAudioGeometrySettings)
+    bool bNeedToSetupDefaultMaterial = true;
+
+    UPROPERTY(GlobalConfig, EditAnywhere, Category = SteamAudioGeometrySettings, meta = (AllowedClasses = "/Script/SteamAudio.SteamAudioMaterial", EditCondition = "bNeedToSetupDefaultMaterial"))
+    FSoftObjectPath DefaultAudioGeometryMaterial;
+
+    UPROPERTY(GlobalConfig, EditAnywhere, Category = SteamAudioGeometrySettings, meta = (AllowedClasses = "/Script/PhysicsCore.PhysicalMaterial"))
+    TMap<FSoftObjectPath, FPhysMatToSteamAudioMatTable_Value> PhysMatToSteamAudioMatTable;
 
     UPROPERTY(GlobalConfig, EditAnywhere, Category = RayTracerSettings)
     ESceneType SceneType;

--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Public/SteamAudioSettings.h
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Public/SteamAudioSettings.h
@@ -109,8 +109,6 @@ struct FSteamAudioSettings
     IPLMaterial DefaultMeshMaterial;
     IPLMaterial DefaultLandscapeMaterial;
     IPLMaterial DefaultBSPMaterial;
-    bool bNeedToSetupDefaultMaterial;
-    IPLMaterial DefaultAudioGeometryMaterial;
     PhysMatToSteamAudioMatTableType* PhysMatToSteamAudioMatTable;
     IPLSceneType SceneType;
     int MaxOcclusionSamples;
@@ -190,12 +188,6 @@ public:
     /** Reference to the Steam Audio Material asset to use as the default material for BSP geometry. */
     UPROPERTY(GlobalConfig, EditAnywhere, Category = SceneExportSettings, meta = (AllowedClasses = "/Script/SteamAudio.SteamAudioMaterial", DisplayName = "Default BSP Material"))
     FSoftObjectPath DefaultBSPMaterial;
-
-    UPROPERTY(GlobalConfig, EditAnywhere, Category = SteamAudioGeometrySettings)
-    bool bNeedToSetupDefaultMaterial = true;
-
-    UPROPERTY(GlobalConfig, EditAnywhere, Category = SteamAudioGeometrySettings, meta = (AllowedClasses = "/Script/SteamAudio.SteamAudioMaterial", EditCondition = "bNeedToSetupDefaultMaterial"))
-    FSoftObjectPath DefaultAudioGeometryMaterial;
 
     UPROPERTY(GlobalConfig, EditAnywhere, Category = SteamAudioGeometrySettings, meta = (AllowedClasses = "/Script/PhysicsCore.PhysicalMaterial"))
     TMap<FSoftObjectPath, FPhysMatToSteamAudioMatTable_Value> PhysMatToSteamAudioMatTable;

--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudioEditor/Private/SteamAudioEditorModule.cpp
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudioEditor/Private/SteamAudioEditorModule.cpp
@@ -298,9 +298,9 @@ void FSteamAudioEditorModule::OnAddGeometryComponentToStaticMeshes()
                 {
                     GeometryComponent->Material = SteamAudioMat->SteamAudioMaterial;
                 }
-                else if (SteamAudioSettings->bNeedToSetupDefaultMaterial)
+                else
                 {
-                    GeometryComponent->Material = SteamAudioSettings->DefaultAudioGeometryMaterial;
+                    GeometryComponent->Material = SteamAudioSettings->DefaultMeshMaterial;
                 }
             }
         }


### PR DESCRIPTION
Adding a Steam Audio Geometry component to an actor requires that you pick one of the Steam Audio Materials for that actor, unless you want to use the default material. This makes the "Add Steam Audio Geometry Component to all actors" less useful, because you still need to set the material for every actor. The thing is, in Unreal we have already set physical materials for all of the actors. It feels silly to have to say "this mesh is brick, and hey Steam, this mesh is brick".

This PR adds a TMap `PhysMatToSteamAudioMatTable` to the plugin settings, where the `Key` is the physical material and the `Value` is the Steam Audio Material.

This PR also adds the ability to select a "default" Steam Audio Material when adding a Geometry Component to All Actors. This means that for all actors whose physical materials do not match the `PhysMatToSteamAudioMatTable`, "default" Steam Audio Material will be created.

There were also some requests on the forums to add this feature:
https://steamcommunity.com/app/596420/discussions/0/6015206719888268562/
https://steamcommunity.com/app/596420/discussions/0/595145594903778702/

### Media

Video demonstrating the feature:

https://github.com/user-attachments/assets/fb42fabf-1973-4ca1-865f-3fb33d5030c4