### PR TITLE
[Unreal] Added the ability to turn off/on Steam Audio dynamically

### DIFF
--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioManager.cpp
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioManager.cpp
@@ -93,6 +93,11 @@ FSteamAudioManager::~FSteamAudioManager()
     ShutDownSteamAudio();
 }
 
+void FSteamAudioManager::SetSteamAudioEnabled(bool bNewIsSteamAudioEnabled)
+{
+    bIsSteamAudioEnabled = bNewIsSteamAudioEnabled;
+}
+
 IPLCoordinateSpace3 FSteamAudioManager::GetListenerCoordinates()
 {
     IPLCoordinateSpace3 ListenerCoordinates{};

--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioManager.h
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioManager.h
@@ -104,6 +104,12 @@ public:
     /** Initializes the global Steam Audio state. */
     bool InitializeSteamAudio(EManagerInitReason Reason);
 
+    /** Sets the Steam Audio enabled mode. */
+    void SetSteamAudioEnabled(bool bNewIsSteamAudioEnabled);
+
+    /** Returns the Steam Audio enabled mode. */
+    bool IsSteamAudioEnabled() { return bIsSteamAudioEnabled; }
+
     /** Shuts down the global Steam Audio state. */
     void ShutDownSteamAudio(bool bResetFlags = true);
 
@@ -138,6 +144,9 @@ public:
     void RemoveListener(USteamAudioListenerComponent* Listener);
 
 private:
+    /** If equal false, then Steam Audio plugins do not affect the sound */
+    bool bIsSteamAudioEnabled = true;
+
     /** The scene type we were actually able to initialize. */
     IPLSceneType ActualSceneType;
 

--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioOcclusion.cpp
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioOcclusion.cpp
@@ -177,6 +177,15 @@ void FSteamAudioOcclusionPlugin::OnReleaseSource(const uint32 SourceId)
 
 void FSteamAudioOcclusionPlugin::ProcessAudio(const FAudioPluginSourceInputData& InputData, FAudioPluginSourceOutputData& OutputData)
 {
+    if (!FSteamAudioModule::GetManager().IsSteamAudioEnabled())
+    {
+        for (int32 i = 0; i < OutputData.AudioBuffer.Num(); ++i)
+        {
+            OutputData.AudioBuffer[i] = (*InputData.AudioBuffer)[i];
+        }
+        return;
+    }
+
     FSteamAudioOcclusionSource& Source = Sources[InputData.SourceId];
 
     float* InBufferData = InputData.AudioBuffer->GetData();

--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioReverb.cpp
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioReverb.cpp
@@ -386,6 +386,15 @@ USoundSubmix* FSteamAudioReverbPlugin::GetSubmix()
 
 void FSteamAudioReverbPlugin::ProcessSourceAudio(const FAudioPluginSourceInputData& InputData, FAudioPluginSourceOutputData& OutputData)
 {
+    if (!FSteamAudioModule::GetManager().IsSteamAudioEnabled())
+    {
+        for (int32 i = 0; i < OutputData.AudioBuffer.Num(); ++i)
+        {
+            OutputData.AudioBuffer[i] = (*InputData.AudioBuffer)[i];
+        }
+        return;
+    }
+
 	FSteamAudioReverbSource& Source = Sources[InputData.SourceId];
     Source.ClearBuffers();
 

--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioSpatialization.cpp
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioSpatialization.cpp
@@ -292,6 +292,15 @@ void FSteamAudioSpatializationPlugin::OnReleaseSource(const uint32 SourceId)
 
 void FSteamAudioSpatializationPlugin::ProcessAudio(const FAudioPluginSourceInputData& InputData, FAudioPluginSourceOutputData& OutputData)
 {
+    if (!FSteamAudioModule::GetManager().IsSteamAudioEnabled())
+    {
+        for (int32 i = 0; i < OutputData.AudioBuffer.Num(); ++i)
+        {
+            OutputData.AudioBuffer[i] = (*InputData.AudioBuffer)[i];
+        }
+        return;
+    }
+
     FSteamAudioSpatializationSource& Source = Sources[InputData.SourceId];
 
     float* InBufferData = InputData.AudioBuffer->GetData();


### PR DESCRIPTION
This PR adds the ability to enable or disable Steam Audio during gameplay. This is implemented through the `SetSteamAudioEnabled` function of the `FSteamAudioManager` class.

There were also some requests on the forums to add this feature:
https://steamcommunity.com/app/596420/discussions/0/4035852798886107497

### Media

Video demonstrating the feature:

https://github.com/user-attachments/assets/bc68d516-9b90-4aba-af88-45be31cd410b