### PR TITLE
[Unreal] Add the ability to select all actors with Geometry Component

### DIFF
--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudioEditor/Private/SteamAudioEditorModule.cpp
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudioEditor/Private/SteamAudioEditorModule.cpp
@@ -158,6 +158,12 @@ void FSteamAudioEditorModule::StartupModule()
 
                     MenuBuilder.BeginSection("GeometryTagging", NSLOCTEXT("SteamAudio", "MenuGeometryTagging", "Geometry Tagging"));
                     MenuBuilder.AddMenuEntry(
+                        NSLOCTEXT("SteamAudio", "MenuAddAllActors", "Select All Actors with Geometry Component"),
+                        NSLOCTEXT("SteamAudio", "MenuAddAllActorsTooltip", "Allows to select all actors that contain a Geometry Component."),
+                        FSlateIcon(),
+                        FUIAction(FExecuteAction::CreateRaw(this, &FSteamAudioEditorModule::OnSelectActorsWithGeometryComponent))
+                    );
+                    MenuBuilder.AddMenuEntry(
                         NSLOCTEXT("SteamAudio", "MenuAddAllActors", "Add Geometry Component to all Actors"),
                         NSLOCTEXT("SteamAudio", "MenuAddAllActorsTooltip", "Add the Steam Audio Geometry component to all actors with static geometry."),
                         FSlateIcon(),
@@ -258,6 +264,20 @@ void FSteamAudioEditorModule::RegisterComponentVisualizer(FName ComponentClassNa
     if (Visualizer.IsValid())
     {
         Visualizer->OnRegister();
+    }
+}
+
+void FSteamAudioEditorModule::OnSelectActorsWithGeometryComponent()
+{
+    UWorld* World = GEditor->GetLevelViewportClients()[0]->GetWorld();
+
+    GEditor->SelectNone(false, true);
+    for (TActorIterator<AActor> It(World); It; ++It)
+    {
+        if (It->FindComponentByClass<USteamAudioGeometryComponent>())
+        {
+            GEditor->SelectActor(*It, true, false);
+        }
     }
 }
 

--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudioEditor/Public/SteamAudioEditorModule.h
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudioEditor/Public/SteamAudioEditorModule.h
@@ -61,6 +61,7 @@ private:
 
     void RegisterComponentVisualizer(FName ComponentClassName, TSharedPtr<FComponentVisualizer> Visualizer);
 
+    void OnSelectActorsWithGeometryComponent();
     void OnAddGeometryComponentToStaticMeshes();
     void OnRemoveGeometryComponentFromStaticMeshes();
     void OnExportStaticGeometry();


### PR DESCRIPTION
Adding the ability to select all actors that contain the Geometry Component. This is implemented as a button in the Steam Audio Editor menu.

### Media

Video demonstrating the feature:

https://github.com/user-attachments/assets/b45a1f2b-5623-4270-9ef5-2d69fe0d01f6


