### PR TITLE
[Unreal] Adding the SteamAudioFunctionLibrary (access to SteamAudio functions in blueprints)

### DIFF
--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioFunctionLibrary.cpp
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioFunctionLibrary.cpp
@@ -1,0 +1,66 @@
+//
+// Copyright 2017-2023 Valve Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "SteamAudioFunctionLibrary.h"
+#include "SteamAudioModule.h"
+#include "SteamAudioManager.h"
+
+using namespace SteamAudio;
+
+bool USteamAudioFunctionLibrary::IsInitialized()
+{
+	return FSteamAudioModule::GetManager().IsInitialized();
+}
+
+void USteamAudioFunctionLibrary::SetSteamAudioEnabled(bool bNewIsSteamAudioEnabled)
+{
+	FSteamAudioModule::GetManager().SetSteamAudioEnabled(bNewIsSteamAudioEnabled);
+}
+
+bool USteamAudioFunctionLibrary::IsSteamAudioEnabled()
+{
+	return FSteamAudioModule::GetManager().IsSteamAudioEnabled();
+}
+
+void USteamAudioFunctionLibrary::ShutDownSteamAudio(bool bResetFlags)
+{
+	FSteamAudioModule::GetManager().ShutDownSteamAudio(bResetFlags);
+}
+
+void USteamAudioFunctionLibrary::UnloadDynamicObject(USteamAudioDynamicObjectComponent* DynamicObjectComponent)
+{
+	FSteamAudioModule::GetManager().UnloadDynamicObject(DynamicObjectComponent);
+}
+
+void USteamAudioFunctionLibrary::AddSource(USteamAudioSourceComponent* Source)
+{
+	FSteamAudioModule::GetManager().AddSource(Source);
+}
+
+void USteamAudioFunctionLibrary::RemoveSource(USteamAudioSourceComponent* Source)
+{
+	FSteamAudioModule::GetManager().RemoveSource(Source);
+}
+
+void USteamAudioFunctionLibrary::AddListener(USteamAudioListenerComponent* Listener)
+{
+	FSteamAudioModule::GetManager().AddListener(Listener);
+}
+
+void USteamAudioFunctionLibrary::RemoveListener(USteamAudioListenerComponent* Listener)
+{
+	FSteamAudioModule::GetManager().RemoveListener(Listener);
+}

--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Public/SteamAudioFunctionLibrary.h
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Public/SteamAudioFunctionLibrary.h
@@ -1,0 +1,68 @@
+//
+// Copyright 2017-2023 Valve Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "SteamAudioFunctionLibrary.generated.h"
+
+class USteamAudioDynamicObjectComponent;
+class USteamAudioListenerComponent;
+class USteamAudioSourceComponent;
+
+UCLASS()
+class STEAMAUDIO_API USteamAudioFunctionLibrary : public UBlueprintFunctionLibrary
+{
+	GENERATED_BODY()
+	
+public:
+	UFUNCTION(BlueprintPure)
+	static bool IsInitialized();
+
+	/** Sets the Steam Audio enabled mode. */
+	UFUNCTION(BlueprintCallable)
+	static void SetSteamAudioEnabled(bool bNewIsSteamAudioEnabled);
+
+	/** Returns the Steam Audio enabled mode. */
+	UFUNCTION(BlueprintPure)
+	static bool IsSteamAudioEnabled();
+
+	/** Shuts down the global Steam Audio state. */
+	UFUNCTION(BlueprintCallable)
+	static void ShutDownSteamAudio(bool bResetFlags = true);
+
+	/** Releases the reference to the geometry and material data for the given Steam Audio Dynamic Mesh component.
+		If the reference count reaches zero, the data is destroyed. */
+	UFUNCTION(BlueprintCallable)
+	static void UnloadDynamicObject(USteamAudioDynamicObjectComponent* DynamicObjectComponent);
+
+	/** Registers a Steam Audio Source component for simulation. */
+	UFUNCTION(BlueprintCallable)
+	static void AddSource(USteamAudioSourceComponent* Source);
+
+	/** Unregisters a Steam Audio Source component from simulation. */
+	UFUNCTION(BlueprintCallable)
+	static void RemoveSource(USteamAudioSourceComponent* Source);
+
+	/** Registers a Steam Audio Listener component for simulation. */
+	UFUNCTION(BlueprintCallable)
+	static void AddListener(USteamAudioListenerComponent* Listener);
+
+	/** Unregisters a Steam Audio Listener component from simulation. */
+	UFUNCTION(BlueprintCallable)
+	static void RemoveListener(USteamAudioListenerComponent* Listener);
+};


### PR DESCRIPTION
Adding a `SteamAudioFunctionLibrary` class, that allows you to access some of the functions from `SteamAudioManager` in blueprints.