### PR TITLE
[Unreal] Replace the tick with the TransformUpdated function in Dynamic Component

### DIFF
--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioDynamicObjectComponent.cpp
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioDynamicObjectComponent.cpp
@@ -28,9 +28,7 @@ USteamAudioDynamicObjectComponent::USteamAudioDynamicObjectComponent()
     , Scene(nullptr)
     , InstancedMesh(nullptr)
 {
-    // Enable ticking.
-    bAutoActivate = true;
-    PrimaryComponentTick.bCanEverTick = true;
+    PrimaryComponentTick.bCanEverTick = false;
 }
 
 FSoftObjectPath USteamAudioDynamicObjectComponent::GetAssetToLoad()
@@ -65,6 +63,7 @@ void USteamAudioDynamicObjectComponent::BeginPlay()
     }
 
     iplInstancedMeshAdd(InstancedMesh, Scene);
+    GetOwner()->GetRootComponent()->TransformUpdated.AddUObject(this, &USteamAudioDynamicObjectComponent::OnTransformUpdated);
 }
 
 void USteamAudioDynamicObjectComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
@@ -82,10 +81,8 @@ void USteamAudioDynamicObjectComponent::EndPlay(const EEndPlayReason::Type EndPl
     Super::EndPlay(EndPlayReason);
 }
 
-void USteamAudioDynamicObjectComponent::TickComponent(float DeltaTime, enum ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
+void USteamAudioDynamicObjectComponent::OnTransformUpdated(USceneComponent* UpdatedComponent, EUpdateTransformFlags UpdateTransformFlags, ETeleportType Teleport)
 {
-    Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
-
     if (Scene && InstancedMesh)
     {
         FTransform RootComponentTransform = GetOwner()->GetRootComponent()->GetComponentTransform();

--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Public/SteamAudioDynamicObjectComponent.h
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Public/SteamAudioDynamicObjectComponent.h
@@ -41,13 +41,6 @@ public:
 
     USteamAudioDynamicObjectComponent();
 
-    /**
-     * Inherited from UActorComponent
-     */
-
-    /** Called once every frame. */
-    virtual void TickComponent(float DeltaTime, enum ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
-
     FSoftObjectPath GetAssetToLoad();
 
 protected:
@@ -67,4 +60,6 @@ private:
 
     /** The Instanced Mesh object. */
     IPLInstancedMesh InstancedMesh;
+
+    void OnTransformUpdated(USceneComponent* UpdatedComponent, EUpdateTransformFlags UpdateTransformFlags, ETeleportType Teleport);
 };


### PR DESCRIPTION
This PR replaces the tick function with a function that is added to the TransformUpdated delegate (called when the actor's transform changes). It is cheaper to perform calculations when the actor's transform actually changes, rather than on every tick.