### PR TITLE
Many GC Allocations fix (Unity + FMOD)

### DIFF
--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/FMODStudio/FMODStudioAudioEngineSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/FMODStudio/FMODStudioAudioEngineSource.cs
@@ -69,7 +69,7 @@ namespace SteamAudio
             if (mEventEmitter != null)
             {
                 var eventInstance = mEventEmitter.EventInstance;
-                if (!eventInstance.Equals(mEventInstance))
+                if (eventInstance.handle != mEventInstance.handle)
                 {
                     // The event instance is different from the one we last used, which most likely means the
                     // event-related objects were destroyed and re-created. Make sure we look for the DSP instance


### PR DESCRIPTION
Previously I created an https://github.com/ValveSoftware/steam-audio/issues/477 for which I created a solution. In the PR list I found that this part of the code had already been changed before https://github.com/ValveSoftware/steam-audio/pull/360. I tried to return the old code and saw that in the new version of FMOD there is no comparison between EventInstance, that is, the old code would not work now, this suggests that the FMOD developers removed the overload of the != operator, most likely because it caused a bug (the one described in https://github.com/ValveSoftware/steam-audio/pull/360). I replaced Equals with handle and got a complete absence of allocations, as well as a solution to the problem described in https://github.com/ValveSoftware/steam-audio/pull/360