### PR TITLE
Fix missing helper include in FindISPC.cmake

### DIFF
--- a/core/build/FindISPC.cmake
+++ b/core/build/FindISPC.cmake
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 include(FindPackageHandleStandardArgs)
+include(SteamAudioHelpers)
 
 get_host_bin_subdir(IPL_BIN_SUBDIR)
 


### PR DESCRIPTION
This doesn't usually cause any problems, but it does if you want a build that uses Embree but has most other features disabled.