### PR TITLE
[Unreal] Fix for the freeze associated with the CleaupDynamicComponentAsset() function

### DIFF
--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioDynamicObjectComponent.cpp
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioDynamicObjectComponent.cpp
@@ -19,7 +19,7 @@
 #include "SteamAudioCommon.h"
 #include "SteamAudioManager.h"
 
-#ifdef WITH_EDITOR
+#if WITH_EDITOR
 #include "Subsystems/EditorAssetSubsystem.h"
 #endif
 
@@ -70,8 +70,10 @@ void USteamAudioDynamicObjectComponent::BeginPlay()
     GetOwner()->GetRootComponent()->TransformUpdated.AddUObject(this, &USteamAudioDynamicObjectComponent::OnTransformUpdated);
 }
 
-void USteamAudioDynamicObjectComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
+void USteamAudioDynamicObjectComponent::BeginDestroy()
 {
+    Super::BeginDestroy();
+
     SteamAudio::FSteamAudioManager& Manager = SteamAudio::FSteamAudioModule::GetManager();
 
     if (Scene && InstancedMesh)
@@ -81,8 +83,6 @@ void USteamAudioDynamicObjectComponent::EndPlay(const EEndPlayReason::Type EndPl
         iplInstancedMeshRelease(&InstancedMesh);
         iplSceneRelease(&Scene);
     }
-
-    Super::EndPlay(EndPlayReason);
 }
 
 void USteamAudioDynamicObjectComponent::OnTransformUpdated(USceneComponent* UpdatedComponent, EUpdateTransformFlags UpdateTransformFlags, ETeleportType Teleport)
@@ -96,10 +96,10 @@ void USteamAudioDynamicObjectComponent::OnTransformUpdated(USceneComponent* Upda
     }
 }
 
-#ifdef WITH_EDITOR
+#if WITH_EDITOR
 void USteamAudioDynamicObjectComponent::CleaupDynamicComponentAsset()
 {
-    if (Asset.IsValid() && bIsAssetActive)
+    if (!Scene && Asset.IsValid() && bIsAssetActive)
     {
         auto EditorAssetSubsystem = GEditor ? GEditor->GetEditorSubsystem<UEditorAssetSubsystem>() : nullptr;
         if (EditorAssetSubsystem)

--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Public/SteamAudioDynamicObjectComponent.h
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Public/SteamAudioDynamicObjectComponent.h
@@ -45,7 +45,7 @@ public:
 
     USteamAudioDynamicObjectComponent();
 
-#ifdef WITH_EDITOR
+#if WITH_EDITOR
     virtual void DestroyComponent(bool bPromoteChildren = false) override;
     virtual void OnComponentDestroyed(bool bDestroyingHierarchy) override;
 #endif
@@ -61,7 +61,7 @@ protected:
     virtual void BeginPlay() override;
 
     /** Called when the component is going to be destroyed. */
-    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+    virtual void BeginDestroy() override;
 
 private:
     /** Retained reference to the main scene used by the Steam Audio Manager for simulation. */
@@ -70,7 +70,7 @@ private:
     /** The Instanced Mesh object. */
     IPLInstancedMesh InstancedMesh;
 
-#ifdef WITH_EDITOR
+#if WITH_EDITOR
     /** Equal true if the asset is not deleted */
     bool bIsAssetActive = true;
 


### PR DESCRIPTION
This PR fixes a freeze that sometimes occurs when exiting the game in the editor. This happens because the `OnComponentDestroyed()` function is called on the Dynamic component when exiting the game, which calls the `CleaupDynamicComponentAsset()` function, which should not be called under these circumstances.