### PR TITLE
[Wwise] Fixed Wwise SDK API Change to Wwise 2024.1.7

### DIFF
--- a/wwise/src/SoundEnginePlugin/SteamAudioSpatializerFX.cpp
+++ b/wwise/src/SoundEnginePlugin/SteamAudioSpatializerFX.cpp
@@ -1,4 +1,4 @@
-/*******************************************************************************
+﻿/*******************************************************************************
 The content of this file includes portions of the AUDIOKINETIC Wwise Technology
 released in source code form as part of the SDK installer package.
 
@@ -570,7 +570,6 @@ void SteamAudioSpatializerFX::Execute(AkAudioBuffer* in_pBuffer, AkUInt32 in_uIn
         pathingParams.binaural = m_params->NonRTPC.pathingBinaural ? IPL_TRUE : IPL_FALSE;
         pathingParams.hrtf = hrtf;
         pathingParams.listener = listenerCoords;
-        pathingParams.normalizeEQ = m_params->NonRTPC.pathingNormalizeEQ ? IPL_TRUE : IPL_FALSE;
 
         iplPathEffectApply(m_pathingEffect, &pathingParams, &m_monoBuffer, &m_ambisonicsOutBuffer);
 

--- a/wwise/src/WwisePlugin/Win32/SteamAudioWwisePluginGUI.h
+++ b/wwise/src/WwisePlugin/Win32/SteamAudioWwisePluginGUI.h
@@ -1,4 +1,4 @@
-/*******************************************************************************
+﻿/*******************************************************************************
 The content of this file includes portions of the AUDIOKINETIC Wwise Technology
 released in source code form as part of the SDK installer package.
 
@@ -28,19 +28,19 @@ the specific language governing permissions and limitations under the License.
 
 #include "../SteamAudioWwisePlugin.h"
 
-class SteamAudioSpatializerPluginGUI final : public AK::Wwise::Plugin::PluginMFCWindows<>, public AK::Wwise::Plugin::GUIWindows
+class SteamAudioSpatializerPluginGUI final : public AK::Wwise::Plugin::GUIWindows<>, public AK::Wwise::Plugin::GUIWindows
 {
 public:
     SteamAudioSpatializerPluginGUI();
 };
 
-class SteamAudioMixReturnPluginGUI final : public AK::Wwise::Plugin::PluginMFCWindows<>, public AK::Wwise::Plugin::GUIWindows
+class SteamAudioMixReturnPluginGUI final : public AK::Wwise::Plugin::GUIWindows<>, public AK::Wwise::Plugin::GUIWindows
 {
 public:
     SteamAudioMixReturnPluginGUI();
 };
 
-class SteamAudioReverbPluginGUI final : public AK::Wwise::Plugin::PluginMFCWindows<>, public AK::Wwise::Plugin::GUIWindows
+class SteamAudioReverbPluginGUI final : public AK::Wwise::Plugin::GUIWindows<>, public AK::Wwise::Plugin::GUIWindows
 {
 public:
     SteamAudioReverbPluginGUI();


### PR DESCRIPTION
This PR updates the Wwise integration to Wwise 2024.1.7:
1. Deleted pathingParams.normalizeEQ in wwise/src/SoundEnginePlugin/SteamAudioSpatializerFX.cpp
2. Renamed AK::Wwise::Plugin::PluginMFCWindows<> into public AK::Wwise::Plugin::GUIWindows<> in wwise/src/WwisePlugin/Win32/SteamAudioWwisePluginGUI.h

After this fix, steam audio wwise is able to successfully compile with UE 5.5.4 & Steam Audio 4.7.0