### PR TITLE
Fix minor issues in SOFA interpolation

### DIFF
--- a/core/src/core/sofa_hrtf_map.cpp
+++ b/core/src/core/sofa_hrtf_map.cpp
@@ -190,7 +190,7 @@ void SOFAHRTFMap::interpolatedHRIRWeights(const Vector3f& direction,
     }
     else
     {
-        while (neighborCoordinates[0] - nearestPosition[0] <= -180.0f)
+        while (neighborCoordinates[1] - nearestPosition[0] <= -180.0f)
         {
             neighborCoordinates[1] += 360.0f;
         }


### PR DESCRIPTION
Hi!

We discovered these minor bugs while using a SOFA file with 2 spheres of data, distinguishing between far-field and near-field audio. The distance was not interpolated correctly, since it assumed either data that would wrap around or had at least 3 spheres. This fix guarantees that `r` will be considered for interpolation even with 2 spheres. When outside the outer one, or inside the inner, the existing `clamp(0, 1)` in the actual linear interpolation takes care of ignoring the other one as expected.

The other fix is what I assume is a typo in azimuth wrapping. Very minor audible impact, if at all, as far as I can tell.

Thanks!