### PR TITLE
[Core] Fix get_dependencies.py for linux-x64 under paths containing /lib

### DIFF
--- a/core/build/get_dependencies.py
+++ b/core/build/get_dependencies.py
@@ -717,7 +717,7 @@ def copy_dependency(name, dep, platform):
                 copy_file(src, dest)
         elif copy_item[0].startswith('install/') and copy_item[0].endswith('/lib'):
             # try lib64 instead of lib
-            src = src.replace('/lib', '/lib64')
+            src = '/lib64'.join(src.rsplit('/lib', 1))
             if os.path.exists(src):
                 if '.' not in src or os.path.isdir(src):
                     copy_directory(src, dest)


### PR DESCRIPTION
The original code for handling `/lib64` in dependencies makes the assumption that the first occurrence of `/lib` in the path is the one for whichever dependency is being processed at the moment, as str.replace() starts from the left. That causes it to break for paths like this:

`/home/user/project/libs/steam-audio/core/deps-build/dep/install/linux-x64/lib64/...`

This patch fixes this by making it replace the first occurrence starting from the right.