### PR TITLE
[core] Fix segfault when `progressCallback` is NULL in `PathBaker`

### DIFF
--- a/core/src/core/path_data.cpp
+++ b/core/src/core/path_data.cpp
@@ -217,7 +217,11 @@ BakedPathData::BakedPathData(const IScene& scene,
     mVisGraph = ipl::make_unique<ProbeVisibilityGraph>(scene, probes, visTester, radius, threshold, visRange,
                                                        numThreads, jobGraph, cancel, progressCallback, callbackUserData);
 
-    threadPool.process(jobGraph, [progressCallback, callbackUserData](float percentComplete) { progressCallback(percentComplete, callbackUserData); });
+    threadPool.process(jobGraph, [progressCallback, callbackUserData](float percentComplete) {
+        if (progressCallback) {
+            progressCallback(percentComplete, callbackUserData);
+        }
+    });
 
     // Next, using multiple threads, calculate shortest paths between every pair of probes.
     PathFinder pathFinder(probes, numThreads);
@@ -246,7 +250,11 @@ BakedPathData::BakedPathData(const IScene& scene,
         });
     }
 
-    threadPool.process(jobGraph, [progressCallback, callbackUserData](float percentComplete) { progressCallback(percentComplete, callbackUserData); });
+    threadPool.process(jobGraph, [progressCallback, callbackUserData](float percentComplete) {
+        if (progressCallback) {
+            progressCallback(percentComplete, callbackUserData);
+        }
+    });
 
     // Remove all data with j > i, since they can be reconstructed from the data with j < i due to symmetry.
     ProbePath invalidProbePath;


### PR DESCRIPTION
Fixes #523

Fixes a segmentation fault that occurs when `iplPathBakerBake()` is called with a `NULL` progress callback parameter.

#### Problem

The `BakedPathData` constructor (called during path baking) passes the `progressCallback` parameter to lambdas within `threadPool.process()` calls without checking if it's `NULL`. The Steam Audio API allows `NULL` callbacks, but the implementation unconditionally dereferences them, causing a segfault.

The problem is absent when the callback is non-NULL, as mentioned here: https://github.com/ValveSoftware/steam-audio/issues/523#issuecomment-3794709812

#### Root Cause

In `core/src/core/path_data.cpp`, the `BakedPathData` constructor contains multiple calls to `threadPool.process()` with lambdas that invoke `progressCallback` without null-checking:

```
cppthreadPool.process(jobGraph, [progressCallback, callbackUserData](float percentComplete) { 
    progressCallback(percentComplete, callbackUserData);  // Crashes if NULL
});
```

This occurs in two locations within the constructor (lines 220 and 249).

#### Solution

Added null checks before all `progressCallback` invocations within lambdas passed to `threadPool.process()`:

```
cppthreadPool.process(jobGraph, [progressCallback, callbackUserData](float percentComplete) { 
    if (progressCallback) {
        progressCallback(percentComplete, callbackUserData);
    }
});
```

#### Testing

The issue can be reproduced with the following minimal test case on macOS arm64 (Steam Audio 4.8.0):

```
#include <stdio.h>
#include <phonon.h>

int main() {
    printf("Starting Steam Audio test...\n");

    // Create context
    IPLContext context = NULL;
    IPLContextSettings contextSettings = {
        .version = STEAMAUDIO_VERSION,
        .logCallback = NULL,
        .allocateCallback = NULL,
        .freeCallback = NULL,
        .simdLevel = IPL_SIMDLEVEL_AVX2
    };

    IPLerror status = iplContextCreate(&contextSettings, &context);
    if (status != IPL_STATUS_SUCCESS) {
        printf("Failed to create context: %d\n", status);
        return 1;
    }
    printf("Context created\n");

    // Create scene
    IPLScene scene = NULL;
    IPLSceneSettings sceneSettings = {
        .type = IPL_SCENETYPE_DEFAULT,
        .closestHitCallback = NULL,
        .anyHitCallback = NULL,
        .batchedClosestHitCallback = NULL,
        .batchedAnyHitCallback = NULL,
        .userData = NULL,
        .embreeDevice = NULL,
        .radeonRaysDevice = NULL
    };

    status = iplSceneCreate(context, &sceneSettings, &scene);
    if (status != IPL_STATUS_SUCCESS) {
        printf("Failed to create scene: %d\n", status);
        return 1;
    }
    printf("Scene created\n");

    // Create static mesh
    IPLVector3 vertices[] = {
        { -50.0f, 0.0f, -50.0f },
        {  50.0f, 0.0f, -50.0f },
        {  50.0f, 0.0f,  50.0f },
        { -50.0f, 0.0f,  50.0f }
    };

    IPLTriangle triangles[] = {
        { {0, 1, 2} },
        { {0, 2, 3} }
    };

    IPLint32 materialIndices[] = { 0, 0 };

    IPLMaterial materials[] = {
        { {0.1f, 0.1f, 0.1f}, 0.5f, {0.0f, 0.0f, 0.0f} }
    };

    IPLStaticMesh staticMesh = NULL;
    IPLStaticMeshSettings meshSettings = {
        .numVertices = 4,
        .numTriangles = 2,
        .numMaterials = 1,
        .vertices = vertices,
        .triangles = triangles,
        .materialIndices = materialIndices,
        .materials = materials
    };

    status = iplStaticMeshCreate(scene, &meshSettings, &staticMesh);
    if (status != IPL_STATUS_SUCCESS) {
        printf("Failed to create static mesh: %d\n", status);
        return 1;
    }
    printf("Static mesh created\n");

    iplStaticMeshAdd(staticMesh, scene);
    iplSceneCommit(scene);
    printf("Scene committed\n");

    // Create probe batch
    IPLProbeBatch probeBatch = NULL;
    status = iplProbeBatchCreate(context, &probeBatch);
    if (status != IPL_STATUS_SUCCESS) {
        printf("Failed to create probe batch: %d\n", status);
        return 1;
    }
    printf("Probe batch created\n");

    // Add probes (commenting these out avoids the crash)
    IPLSphere probe1 = { {0.0f, 1.5f, 0.0f}, 1.0f };
    IPLSphere probe2 = { {10.0f, 1.5f, 0.0f}, 1.0f };

    iplProbeBatchAddProbe(probeBatch, probe1);
    iplProbeBatchAddProbe(probeBatch, probe2);
    iplProbeBatchCommit(probeBatch);

    IPLint32 numProbes = iplProbeBatchGetNumProbes(probeBatch);
    printf("Probe batch has %d probes\n", numProbes);

    // Bake pathing data
    IPLBakedDataIdentifier identifier = {
        .type = IPL_BAKEDDATATYPE_PATHING,
        .variation = IPL_BAKEDDATAVARIATION_DYNAMIC,
        .endpointInfluence = { {0.0f, 0.0f, 0.0f}, 0.0f }
    };

    IPLPathBakeParams params = {
        .scene = scene,
        .probeBatch = probeBatch,
        .identifier = identifier,
        .numSamples = 1,
        .radius = 1.0f,
        .threshold = 0.5f,
        .visRange = 50.0f,
        .pathRange = 100.0f,
        .numThreads = 1
    };

    printf("Calling iplPathBakerBake...\n");
    fflush(stdout);

    // SEGFAULTS HERE
    iplPathBakerBake(context, &params, NULL, NULL);

    printf("Success!\n");

    // Cleanup
    iplProbeBatchRelease(&probeBatch);
    iplStaticMeshRemove(staticMesh, scene);
    iplStaticMeshRelease(&staticMesh);
    iplSceneRelease(&scene);
    iplContextRelease(&context);

    return 0;
}
```

Output:

```
Starting Steam Audio test...
Context created
Scene created
Static mesh created
Scene committed
Probe batch created
Probe batch has 2 probes
Calling iplPathBakerBake...
zsh: segmentation fault  ./test
```

After the fix:

```
Starting Steam Audio test...
Context created
Scene created
Static mesh created
Scene committed
Probe batch created
Probe batch has 2 probes
Calling iplPathBakerBake...
Success!
```