### PR TITLE
[Unreal] Add log for invalid static mesh during static export

### DIFF
--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioScene.cpp
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioScene.cpp
@@ -201,7 +201,10 @@ static bool ExportStaticMeshComponentsForActor(AStaticMeshActor* StaticMeshActor
     {
         UStaticMesh* StaticMesh = StaticMeshComponent->GetStaticMesh();
         if (!StaticMesh || !StaticMesh->HasValidRenderData())
+        {
+            UE_LOG(LogSteamAudio, Error, TEXT("Static Mesh Component %s on actor %s doesn't have a valid static mesh, or it doesn't have valid render data"), *StaticMeshComponent->GetName(), *StaticMeshComponent->GetOwner()->GetName());
             return false;
+        }
 
         if (!ExportStaticMeshComponent(StaticMeshComponent, Vertices, Triangles, MaterialIndices, Materials, MaterialIndexForAsset, bRelativePositions))
             return false;


### PR DESCRIPTION
While I was exporting static geometry for the first time, a single static mesh component had an invalid static mesh which failed the whole export without feedback. This log was useful to me for catching which actor/component it was.