### PR TITLE
Fix corrupted `userData` in `iplDirectivityCalculate` callback

### DIFF
--- a/core/src/core/directivity.h
+++ b/core/src/core/directivity.h
@@ -24,7 +24,7 @@ namespace ipl {
 // Directivity
 // --------------------------------------------------------------------------------------------------------------------
 
-typedef float (IPL_CALLBACK *DirectivityCallback)(const Vector3f& direction,
+typedef float (IPL_CALLBACK *DirectivityCallback)(Vector3f direction,
                                                   void* userData);
 
 class Directivity


### PR DESCRIPTION
Fixes #526

The `iplDirectivityCalculate` function was not correctly forwarding the `userData` pointer to directivity callbacks. Instead of passing the user-provided pointer, it would pass an incorrect memory address, causing crashes when trying to dereference `userData` in the callback.

The callback function signatures differed in how they passed the direction vector:

- C (`IPLDirectivityCallback`): passes `IPLVector3` by value
- Internal API (`DirectivityCallback`): passes `Vector3f` by reference

This difference caused member offsets to be misaligned when `reinterpret_cast` was used to convert between the types in `api_advanced_simulation.cpp`, resulting in `userData` being read from the wrong memory location.

### Solution

Changed the `DirectivityCallback` signature to pass `Vector3f` by value instead of by reference, matching the C API layout.

The test case from issue #526 now passes correctly with different `userData` pointers being properly forwarded:

```
=== Test 1 ===
Expected userData: 0x16f60ede8
Expected value:    0xdeadbeefcafebabe

Callback received userData: 0x16f60ede8
Value at userData: 0xdeadbeefcafebabe

=== Test 2 ===
Expected userData: 0x16f60ed50
Expected value:    0xfeedfacedeadc0de

Callback received userData: 0x16f60ed50
Value at userData: 0xfeedfacedeadc0de
```