### PR TITLE
Fix Ambisonic Conversion

### DIFF
--- a/core/src/core/audio_buffer.cpp
+++ b/core/src/core/audio_buffer.cpp
@@ -143,12 +143,12 @@ void AudioBuffer::convertAmbisonics(AmbisonicsType inType,
         2.0f / sqrtf(3.0f),
         2.0f / sqrtf(3.0f),
         1.0f,
-        sqrtf(45.0f) / 32.0f,
-        sqrtf(45.0f) / 32.0f,
+        sqrtf(45.0f / 32.0f),
+        sqrtf(45.0f / 32.0f),
         3.0f / sqrtf(5.0f),
         3.0f / sqrtf(5.0f),
-        sqrtf(8.0f) / 5.0f,
-        sqrtf(8.0f) / 5.0f
+        sqrtf(8.0f / 5.0f),
+        sqrtf(8.0f / 5.0f)
     };
 
     for (auto inIndex = 0; inIndex < numChannels; ++inIndex)


### PR DESCRIPTION
Hi, I noticed that SteamAudio's constants for ambisonic format conversion differ from the ones in the [Wikipedia table](https://en.wikipedia.org/wiki/Ambisonic_data_exchange_formats) and other ambisonic conversion code I could find.  It seems like the square root was dropped from the denominator when simplifying expressions like `sqrt(7) * (sqrt(45)/sqrt(224))`.