### PR TITLE
[Core] Fix unaligned load of m128 floats in ArrayMath::multiplyAccumulate

### DIFF
--- a/core/src/core/array_math.cpp
+++ b/core/src/core/array_math.cpp
@@ -238,7 +238,7 @@ void ArrayMath::multiplyAccumulate(int size,
 
             auto y = float4::add(float4::mul(b1, x2), float4::mul(b0, float4::mul(b3, b4)));
 
-            y = float4::add(y, float4::load(&outData[i]));
+            y = float4::add(y, float4::loadu(&outData[i]));
 
             float4::store(&outData[i], y);
         }

--- a/core/src/core/array_math.cpp
+++ b/core/src/core/array_math.cpp
@@ -238,7 +238,7 @@ void ArrayMath::multiplyAccumulate(int size,
 
             auto y = float4::add(float4::mul(b1, x2), float4::mul(b0, float4::mul(b3, b4)));
 
-            y = float4::add(y, float4::loadu(&outData[i]));
+            y = float4::add(y, float4::load(&outData[i]));
 
             float4::store(&outData[i], y);
         }
@@ -257,7 +257,7 @@ void ArrayMath::multiplyAccumulate(int size,
 
             auto y = float4::add(float4::mul(b1, x2), float4::mul(b0, float4::mul(b3, b4)));
 
-            y = float4::add(y, float4::load(&outData[i]));
+            y = float4::add(y, float4::loadu(&outData[i]));
 
             float4::storeu(&outData[i], y);
         }


### PR DESCRIPTION
Fix for https://github.com/ValveSoftware/steam-audio/issues/546

On linux, this can sometimes cause a segfault when the data is not 16 byte aligned. The other loads are all unaligned, but the final load was expecting aligned data, causing a segfault on linux. On windows, it seems this was not strictly enforced by MSVC, so the loads worked just fine.