### PR TITLE
[FMOD] Fix fully occluded events in FMOD Studio

### DIFF
--- a/fmod/src/spatialize_effect.cpp
+++ b/fmod/src/spatialize_effect.cpp
@@ -954,7 +954,8 @@ IPLDirectEffectParams getDirectParams(FMOD_DSP_STATE* state,
     }
     else
     {
-        params.flags = static_cast<IPLDirectEffectFlags>(params.flags | IPL_DIRECTEFFECTFLAGS_APPLYOCCLUSION);
+        if (effect->applyOcclusion == PARAMETER_USERDEFINED || hasSource)
+            params.flags = static_cast<IPLDirectEffectFlags>(params.flags | IPL_DIRECTEFFECTFLAGS_APPLYOCCLUSION);
 
         if (effect->applyOcclusion == PARAMETER_USERDEFINED)
         {
@@ -962,8 +963,9 @@ IPLDirectEffectParams getDirectParams(FMOD_DSP_STATE* state,
         }
         else
         {
-            if (updatingOverallGain && !hasSource)
+            if (!hasSource)
             {
+                // No simulation source (e.g. in the FMOD Studio editor preview) should fall back to fully unoccluded
                 params.occlusion = 1.0f;
             }
         }

--- a/fmod/src/spatialize_effect.cpp
+++ b/fmod/src/spatialize_effect.cpp
@@ -948,28 +948,23 @@ IPLDirectEffectParams getDirectParams(FMOD_DSP_STATE* state,
         }
     }
 
-    if (effect->applyOcclusion == PARAMETER_DISABLE)
-    {
-        params.occlusion = 1.0f;
-    }
-    else
-    {
-        if (effect->applyOcclusion == PARAMETER_USERDEFINED || hasSource)
-            params.flags = static_cast<IPLDirectEffectFlags>(params.flags | IPL_DIRECTEFFECTFLAGS_APPLYOCCLUSION);
-
-        if (effect->applyOcclusion == PARAMETER_USERDEFINED)
-        {
-            params.occlusion = effect->occlusion;
-        }
-        else
-        {
-            if (!hasSource)
-            {
-                // No simulation source (e.g. in the FMOD Studio editor preview) should fall back to fully unoccluded
-                params.occlusion = 1.0f;
-            }
-        }
-    }
+	switch (effect->applyOcclusion)
+	{
+	case PARAMETER_DISABLE:
+		params.occlusion = 1.0f;
+		break;
+	case PARAMETER_SIMULATIONDEFINED:
+		if (hasSource)
+			params.flags = static_cast<IPLDirectEffectFlags>(params.flags | IPL_DIRECTEFFECTFLAGS_APPLYOCCLUSION);
+		else
+			// No simulation source (e.g. in the FMOD Studio editor preview) should fall back to fully unoccluded
+			params.occlusion = 1.0f;
+		break;
+	case PARAMETER_USERDEFINED:
+		params.flags = static_cast<IPLDirectEffectFlags>(params.flags | IPL_DIRECTEFFECTFLAGS_APPLYOCCLUSION);
+		params.occlusion = effect->occlusion;
+		break;
+	}
 
     if (effect->applyTransmission == PARAMETER_DISABLE)
     {


### PR DESCRIPTION
This PR fixes #552 by changing some checks that would cause a source to be always fully occluded when previewing a sound in FMOD Studio. It also rewrites the occlusion parameter handling from nested ifs into a flat switch case for easier readability.