### PR TITLE
[core] improve compatibility with CMake 3.15+ on Windows

### DIFF
--- a/core/build/dependencies.json
+++ b/core/build/dependencies.json
@@ -278,6 +278,12 @@
                     ]
                 },
                 {
+                    "platforms": ["windows-x86", "windows-x64"],
+                    "flags": [
+                        "-DCMAKE_POLICY_DEFAULT_CMP0091=NEW"
+                    ]
+                },
+                {
                     "stamp": false,
                     "flags": [
                         "-DZLIB_ROOT=$deps/zlib/lib/$platform/$config",


### PR DESCRIPTION
I was unable to build Steam Audio Core following its [instructions](https://valvesoftware.github.io/steam-audio/doc/capi/build-instructions.html#building-the-sdk) using CMake 3.31.9 on Windows 10. After a successful run of `get_dependencies.py`, running `build.py` works for compilation but fails when linking mysofa:
```
LINK : warning LNK4098: defaultlib "MSVCRT" conflicts with use of other libs; use /NODEFAULTLIB:library
mysofa.lib(check.obj) : error LNK2001: unresolved external symbol "_imp__stdio_common_vsscanf".
steam-audio\core\build\windows-vs2022-x64\src\core\Release\phonon.dll : fatal error LNK1120: 1 unresolved externals
```

This was due to CMake 3.15 introducing policy CMP0091 (https://cmake.org/cmake/help/v3.15/policy/CMP0091.html). Since libmysofa declares the minimum required version to be 3.5, it forces CMP0091 to be value OLD when using CMake v3.15+ which ignores `CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded` passed from `get_dependencies.py` to mysofa.  

To work around this without changing mysofa versions or making upstream changes to mysofa, `dependencies.json` now explicitly sets the policy to NEW on Windows, so the intended /MT flag from `get_dependencies.py` will be set with CMake v3.15+ as well.