### PR TITLE
[FMOD] Find Steam Audio Spatializer instance on all tracks of an event instance

### DIFF
--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/FMODStudio/FMODStudioAudioEngineSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/FMODStudio/FMODStudioAudioEngineSource.cs
@@ -98,29 +98,32 @@ namespace SteamAudio
             if (!mEventInstance.isValid())
                 return;
 
-            FMOD.ChannelGroup channelGroup;
-            mEventInstance.getChannelGroup(out channelGroup);
+            mEventInstance.getChannelGroup(out var channelGroup);
+            mFoundDSP = FindDSPInChannelGroup(channelGroup);
+        }
 
-            int numDSPs;
-            channelGroup.getNumDSPs(out numDSPs);
-
+        bool FindDSPInChannelGroup(FMOD.ChannelGroup channelGroup)
+        {
+            channelGroup.getNumDSPs(out var numDSPs);
             for (var i = 0; i < numDSPs; ++i)
             {
                 channelGroup.getDSP(i, out mDSP);
-
-                var dspName = "";
-                var dspVersion = 0u;
-                var dspNumChannels = 0;
-                var dspConfigWidth = 0;
-                var dspConfigHeight = 0;
-                mDSP.getInfo(out dspName, out dspVersion, out dspNumChannels, out dspConfigWidth, out dspConfigHeight);
+                mDSP.getInfo(out var dspName, out _, out _, out _, out _);
 
                 if (dspName == "Steam Audio Spatializer")
-                {
-                    mFoundDSP = true;
-                    return;
-                }
+                    return true;
             }
+
+            channelGroup.getNumGroups(out var numGroups);
+            for (var i = 0; i < numGroups; ++i)
+            {
+                channelGroup.getGroup(i, out var childGroup);
+                
+                if (FindDSPInChannelGroup(childGroup))
+                    return true;
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
This PR makes FindDSP() able to detect the Steam Audio Spatializer plugin on all tracks of an FMOD event by changing the search to a recursive function. This allows sound designers to place the spatializer anywhere in an FMOD event for more complex routing and processing scenarios.

Also inlined the out variables for easier readability and renamed unused variables to _.