### PR TITLE
[Core] [FMOD] Neutral panning when source is close to listener

### DIFF
--- a/core/src/core/api_geometry.cpp
+++ b/core/src/core/api_geometry.cpp
@@ -41,7 +41,7 @@ IPLVector3 CContext::calculateRelativeDirection(IPLVector3 sourcePosition,
     auto _listenerRight = Vector3f::unitVector(Vector3f::cross(_listenerAhead, _listenerUp));
 
     auto listenerToSource = _sourcePosition - _listenerPosition;
-    auto _relativeDirection = Vector3f::kYAxis;
+    auto _relativeDirection = Vector3f(0.f, 0.f, -1.f);
 
     if (listenerToSource.length() > 1e-5f)
     {
@@ -52,8 +52,7 @@ IPLVector3 CContext::calculateRelativeDirection(IPLVector3 sourcePosition,
         _relativeDirection.z() = (-Vector3f::dot(listenerToSource, _listenerAhead));
     }
 
-    IPLVector3 relativeDirection = {_relativeDirection.x(), _relativeDirection.y(), _relativeDirection.z()};
-    return relativeDirection;
+    return {_relativeDirection.x(), _relativeDirection.y(), _relativeDirection.z()};
 }
 
 }

--- a/fmod/src/spatialize_effect.cpp
+++ b/fmod/src/spatialize_effect.cpp
@@ -1032,6 +1032,12 @@ FMOD_RESULT F_CALL process(FMOD_DSP_STATE* state,
 
     auto sourceCoordinates = calcCoordinates(effect->source.absolute);
     auto listenerCoordinates = calcListenerCoordinates(state);
+    if (sourceCoordinates.origin.x == listenerCoordinates.origin.x &&
+        sourceCoordinates.origin.y == listenerCoordinates.origin.y &&
+        sourceCoordinates.origin.z == listenerCoordinates.origin.z)
+    {
+        sourceCoordinates.origin.z -= 1e-4f;
+    }
 
     if (operation == FMOD_DSP_PROCESS_QUERY)
     {


### PR DESCRIPTION
This PR fixes #557.  

The calculateRelativeDirection() function returns kYAxis when the distance between source and listener is smaller than 0.00001 which causes Steam Audio to render the sound from the left on a speaker array. While there is no right answer to the situation that source and listener are at exactly the same position, generally returning Steam Audio's front vector will lead to more neutral results. One such example is previewing sound events in a middleware like FMOD Studio where the listener defaults to the source's location.  

As an additional safety measure, the Steam Audio Spatializer (FMOD) now checks if the source and listener are at exactly the same position and nudges the source 0.0001 to the listener's front. That nudging though is a magic number depending on another magic number from the core library, so should someone change the threshold in the core library to something like 0.01, it won't be effective anymore.