### PR TITLE
Refactor/performance improvement

### DIFF
--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioBakedListenerInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioBakedListenerInspector.cs
@@ -91,7 +91,7 @@ namespace SteamAudio
         [MenuItem("Steam Audio/Steam Audio Baked Listener/Bake All Static Listener Reflections In Current Scene", false, 65)]
         public static void BakeAllReflectionsInScene()
         {
-            var bakedListeners = FindObjectsByType<SteamAudioBakedListener>(FindObjectsSortMode.None);
+            var bakedListeners = FindObjectsByType<SteamAudioBakedListener>();
             if (bakedListeners.Length == 0)
             {
                 EditorUtility.DisplayDialog(

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioBakedSourceInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioBakedSourceInspector.cs
@@ -91,7 +91,7 @@ namespace SteamAudio
         [MenuItem("Steam Audio/Steam Audio Baked Source/Bake All Static Source Reflections In Current Scene", false, 65)]
         public static void BakeAllReflectionsInScene()
         {
-            var bakedSources = FindObjectsByType<SteamAudioBakedSource>(FindObjectsSortMode.None);
+            var bakedSources = FindObjectsByType<SteamAudioBakedSource>();
             if (bakedSources.Length == 0)
             {
                 EditorUtility.DisplayDialog(

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioListenerInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioListenerInspector.cs
@@ -102,7 +102,7 @@ namespace SteamAudio
         [MenuItem("Steam Audio/Steam Audio Listener/Bake All Reverb In Current Scene", false, 64)]
         public static void BakeAllReverbInScene()
         {
-            var listeners = FindObjectsByType<SteamAudioListener>(FindObjectsSortMode.None);
+            var listeners = FindObjectsByType<SteamAudioListener>();
             if (listeners.Length == 0)
             {
                 EditorUtility.DisplayDialog(

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioProbeBatchInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioProbeBatchInspector.cs
@@ -137,7 +137,7 @@ namespace SteamAudio
         [MenuItem("Steam Audio/Steam Audio Probe Batch/Bake All Pathing In Current Scene", false, 63)]
         public static void BakeAllPathingInScene()
         {
-            var probeBatches = FindObjectsByType<SteamAudioProbeBatch>(FindObjectsSortMode.None);
+            var probeBatches = FindObjectsByType<SteamAudioProbeBatch>();
             if (probeBatches.Length == 0)
             {
                 EditorUtility.DisplayDialog(

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioReverbDataPointInspector.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Editor/SteamAudioReverbDataPointInspector.cs
@@ -65,7 +65,7 @@ namespace SteamAudio
         [MenuItem("Steam Audio/Steam Audio Reverb Data Point/Bake All", false, 61)]
         public static void BakeAllProbes()
         {
-            var allProbes = FindObjectsByType<SteamAudioReverbDataPoint>(FindObjectsSortMode.None);
+            var allProbes = FindObjectsByType<SteamAudioReverbDataPoint>();
 
             if (allProbes.Length == 0)
             {

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/FMODStudio/FMODStudioAudioEngineState.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/FMODStudio/FMODStudioAudioEngineState.cs
@@ -57,13 +57,17 @@ namespace SteamAudio
     {
         public override Transform GetListenerTransform()
         {
+#if UNITY_2022_3_OR_NEWER
+            var fmodStudioListener = (MonoBehaviour) GameObject.FindAnyObjectByType<FMODUnity.StudioListener>();
+#else
             var fmodStudioListener = (MonoBehaviour) GameObject.FindObjectOfType<FMODUnity.StudioListener>();
+#endif
             return (fmodStudioListener != null) ? fmodStudioListener.transform : null;
         }
 
         public override AudioSettings GetAudioSettings()
         {
-            var audioSettings = new AudioSettings { };
+            var audioSettings = new AudioSettings();
 
             int samplingRate = 0;
             FMOD.SPEAKERMODE speakerMode = FMOD.SPEAKERMODE.DEFAULT;

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/Baker.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/Baker.cs
@@ -96,7 +96,7 @@ namespace SteamAudio
 
             if (staticMeshComponent == null || staticMeshComponent.asset == null)
             {
-                Debug.LogError(string.Format("Scene {0} has not been exported. Click Steam Audio > Export Active Scene to do so.", SceneManager.GetActiveScene().name));
+                Debug.LogError($"Scene {SceneManager.GetActiveScene().name} has not been exported. Click Steam Audio > Export Active Scene to do so.");
                 return;
             }
 
@@ -213,14 +213,14 @@ namespace SteamAudio
 #if UNITY_EDITOR
             var progress = ((sNumSubTasksCompleted + sProgress) / Mathf.Max(sNumSubTasks, 1)) + .01f; // Adding an offset because progress bar when it is exact 0 has some non-zero progress.
 
-            var progressString = string.Format("Task {0} / {1} [{2}]", taskIndex + 1, numTasks, taskName);
+            var progressString = $"Task {taskIndex + 1} / {numTasks} [{taskName}]";
             if (subTaskName != null)
             {
-                progressString += string.Format(", Probe Batch {0} / {1} [{2}]", subTaskIndex + 1, numSubTasks, subTaskName);
+                progressString += $", Probe Batch {subTaskIndex + 1} / {numSubTasks} [{subTaskName}]";
             }
 
             var progressPercent = Mathf.FloorToInt(Mathf.Min(progress * 100.0f, 100.0f));
-            progressString += string.Format(" ({0}% complete)", progressPercent);
+            progressString += $" ({progressPercent}% complete)";
 
             Progress.Report(sProgressId, progress, progressString);
 #endif
@@ -292,15 +292,15 @@ namespace SteamAudio
                 var taskName = "";
                 if (sTasks[i].identifier.type == BakedDataType.Pathing)
                 {
-                    taskName = string.Format("{0} (Pathing)", sTasks[i].name);
+                    taskName = $"{sTasks[i].name} (Pathing)";
                 }
                 else if (sTasks[i].identifier.variation == BakedDataVariation.Reverb)
                 {
-                    taskName = string.Format("{0} (Reverb)", sTasks[i].name);
+                    taskName = $"{sTasks[i].name} (Reverb)";
                 }
                 else
                 {
-                    taskName = string.Format("{0} (Reflections)", sTasks[i].name);
+                    taskName = $"{sTasks[i].name} (Reflections)";
                 }
 
                 sCurrentTask = i;
@@ -309,26 +309,27 @@ namespace SteamAudio
                 sNumSubTasksInCurrentTask = 0;
                 sCurrentSubTaskName = null;
 
-                Debug.Log(string.Format("START: Baking effect for {0}.", taskName));
+                Debug.Log($"START: Baking effect for {taskName}.");
 
                 if (sTasks[i].probeBatches != null)
                 {
                     var probeBatches = sTasks[i].probeBatches;
 
-                    for (var j = 0; j < probeBatches.Length; ++j)
+                    int probeCount = probeBatches.Length;
+                    for (var j = 0; j < probeCount; ++j)
                     {
                         if (sCancel)
                             return;
 
                         if (probeBatches[j] == null)
                         {
-                            Debug.LogWarning(string.Format("{0}: Probe Batch at index {1} is null, skipping.", taskName, j));
+                            Debug.LogWarning($"{taskName}: Probe Batch at index {j} is null, skipping.");
                             continue;
                         }
 
                         if (probeBatches[j].GetNumProbes() == 0)
                         {
-                            Debug.LogWarning(string.Format("{0}: Probe Batch {1} has no probes, skipping.", taskName, sTasks[i].probeBatchNames[j]));
+                            Debug.LogWarning($"{taskName}: Probe Batch {sTasks[i].probeBatchNames[j]} has no probes, skipping.");
                             continue;
                         }
 
@@ -546,7 +547,7 @@ namespace SteamAudio
                     UpdateBakeProgress(i, sTasks.Length, taskName);
                 }
 
-                Debug.Log(string.Format("COMPLETED: Baking effect for {0}.", taskName));
+                Debug.Log($"COMPLETED: Baking effect for {taskName}.");
             }
 
             sStatus = BakeStatus.Complete;

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/Context.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/Context.cs
@@ -38,7 +38,7 @@ namespace SteamAudio
 
             var status = API.iplContextCreate(ref contextSettings, out mContext);
             if (status != Error.Success)
-                throw new Exception(string.Format("Unable to create context. [{0}]", status));
+                throw new Exception($"Unable to create context. [{status}]");
         }
 
         public Context(Context context)
@@ -62,7 +62,7 @@ namespace SteamAudio
         }
 
         [MonoPInvokeCallback(typeof(LogCallback))]
-        public static void LogMessage(LogLevel level, string message)
+        public void LogMessage(LogLevel level, string message)
         {
             switch (level)
             {

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/EmbreeDevice.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/EmbreeDevice.cs
@@ -28,7 +28,7 @@ namespace SteamAudio
 
             var status = API.iplEmbreeDeviceCreate(context.Get(), ref embreeDeviceSettings, out mEmbreeDevice);
             if (status != Error.Success)
-                throw new Exception(string.Format("Unable to create Embree device. [{0}]", status));
+                throw new Exception($"Unable to create Embree device. [{status}]");
         }
 
         public EmbreeDevice(EmbreeDevice embreeDevice)

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/HRTF.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/HRTF.cs
@@ -55,12 +55,12 @@ namespace SteamAudio
             var status = API.iplHRTFCreate(context.Get(), ref audioSettings, ref hrtfSettings, out mHRTF);
             if (status != Error.Success)
             {
-                Debug.LogError(string.Format("Unable to load HRTF: {0}. [{1}]", (sofaFileName != null) ? sofaFileName : "default", status));
+                Debug.LogError($"Unable to load HRTF: {((sofaFileName != null) ? sofaFileName : "default")}. [{status}]");
                 mHRTF = IntPtr.Zero;
             }
             else
             {
-                Debug.Log(string.Format("Loaded HRTF: {0}.", (sofaFileName != null) ? sofaFileName : "default"));
+                Debug.Log($"Loaded HRTF: {((sofaFileName != null) ? sofaFileName : "default")}.");
             }
 
             if (sofaData != IntPtr.Zero)
@@ -89,7 +89,7 @@ namespace SteamAudio
             return mHRTF;
         }
 
-        private float dBToGain(float gaindB)
+        private static float dBToGain(float gaindB)
         {
             const float kMinDBLevel = -90.0f;
 

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/InstancedMesh.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/InstancedMesh.cs
@@ -32,7 +32,7 @@ namespace SteamAudio
 
             var status = API.iplInstancedMeshCreate(scene.Get(), ref instancedMeshSettings, out mInstancedMesh);
             if (status != Error.Success)
-                throw new Exception(string.Format("Unable to create instanced mesh ({0}). [{1}]", transform.gameObject.name, status));
+                throw new Exception($"Unable to create instanced mesh ({transform.gameObject.name}). [{status}]");
         }
 
         public InstancedMesh(InstancedMesh instancedMesh)

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/OpenCLDevice.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/OpenCLDevice.cs
@@ -35,7 +35,7 @@ namespace SteamAudio
             var deviceList = IntPtr.Zero;
             var status = API.iplOpenCLDeviceListCreate(context.Get(), ref deviceSettings, out deviceList);
             if (status != Error.Success)
-                throw new Exception(string.Format("Unable to enumerate OpenCL devices. [{0}]", status));
+                throw new Exception($"Unable to enumerate OpenCL devices. [{status}]");
 
             var numDevices = API.iplOpenCLDeviceListGetNumDevices(deviceList);
             if (numDevices <= 0)
@@ -54,7 +54,7 @@ namespace SteamAudio
                 deviceSettings.fractionCUsForIRUpdate = 0.0f;
                 status = API.iplOpenCLDeviceListCreate(context.Get(), ref deviceSettings, out deviceList);
                 if (status != Error.Success)
-                    throw new Exception(string.Format("Unable to enumerate OpenCL devices. [{0}]", status));
+                    throw new Exception($"Unable to enumerate OpenCL devices. [{status}]");
 
                 numDevices = API.iplOpenCLDeviceListGetNumDevices(deviceList);
                 if (numDevices <= 0)
@@ -65,7 +65,7 @@ namespace SteamAudio
             if (status != Error.Success)
             {
                 API.iplOpenCLDeviceListRelease(ref deviceList);
-                throw new Exception(string.Format("Unable to create OpenCL device. [{0}]", status));
+                throw new Exception($"Unable to create OpenCL device. [{status}]");
             }
 
             API.iplOpenCLDeviceListRelease(ref deviceList);

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/ProbeBatch.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/ProbeBatch.cs
@@ -86,7 +86,7 @@ namespace SteamAudio
             var status = API.iplProbeBatchLoad(context.Get(), serializedObject.Get(), out mProbeBatch);
             if (status != Error.Success)
             {
-                Debug.LogError(string.Format("Unable to load Probe Batch from {0}.", dataAsset.name));
+                Debug.LogError($"Unable to load Probe Batch from {dataAsset.name}.");
                 mProbeBatch = IntPtr.Zero;
             }
 

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/RadeonRaysDevice.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/RadeonRaysDevice.cs
@@ -28,7 +28,7 @@ namespace SteamAudio
 
             var status = API.iplRadeonRaysDeviceCreate(openCLDevice.Get(), ref deviceSettings, out mRadeonRaysDevice);
             if (status != Error.Success)
-                throw new Exception(string.Format("Unable to create Radeon Rays device. [{0}]", status));
+                throw new Exception($"Unable to create Radeon Rays device. [{status}]");
         }
 
         public RadeonRaysDevice(RadeonRaysDevice device)

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/Scene.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/Scene.cs
@@ -38,7 +38,7 @@ namespace SteamAudio
 
             var status = API.iplSceneCreate(context.Get(), ref sceneSettings, out mScene);
             if (status != Error.Success)
-                throw new Exception(string.Format("Unable to create scene [{0}]", status.ToString()));
+                throw new Exception($"Unable to create scene [{status.ToString()}]");
         }
 
         public Scene(Context context, SceneSettings sceneSettings, SerializedData dataAsset)
@@ -48,7 +48,7 @@ namespace SteamAudio
             var serializedObject = new SerializedObject(context, dataAsset);
             var status = API.iplSceneLoad(context.Get(), ref sceneSettings, serializedObject.Get(), null, IntPtr.Zero, out mScene);
             if (status != Error.Success)
-                throw new Exception(string.Format("Unable to load scene [{0}]", status.ToString()));
+                throw new Exception($"Unable to load scene [{status.ToString()}]");
 
             serializedObject.Release();
         }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SerializedData.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SerializedData.cs
@@ -32,7 +32,7 @@ namespace SteamAudio
             var fileName = EditorUtility.SaveFilePanelInProject("Export", defaultFileName, "asset",
                 "Select a file to export data to.");
 
-            if (fileName != null && fileName.Length > 0)
+            if (!string.IsNullOrEmpty(fileName))
             {
                 var dataAsset = ScriptableObject.CreateInstance<SerializedData>();
                 AssetDatabase.CreateAsset(dataAsset, fileName);

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/Simulator.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/Simulator.cs
@@ -28,7 +28,7 @@ namespace SteamAudio
         {
             var status = API.iplSimulatorCreate(context.Get(), ref simulationSettings, out mSimulator);
             if (status != Error.Success)
-                throw new Exception(string.Format("Unable to create simulator. [{0}]", status));
+                throw new Exception($"Unable to create simulator. [{status}]");
         }
 
         public Simulator(Simulator simulator)
@@ -103,7 +103,7 @@ namespace SteamAudio
 
             var status = API.iplSourceCreate(simulator.Get(), ref sourceSettings, out mSource);
             if (status != Error.Success)
-                throw new Exception(string.Format("Unable to create source for simulation. [{0}]", status));
+                throw new Exception($"Unable to create source for simulation. [{status}]");
         }
 
         public Source(Source source)

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/StaticMesh.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/StaticMesh.cs
@@ -63,9 +63,7 @@ namespace SteamAudio
             var status = API.iplStaticMeshCreate(scene.Get(), ref staticMeshSettings, out mStaticMesh);
             if (status != Error.Success)
             {
-                throw new Exception(string.Format("Unable to create static mesh for export ({0} vertices, {1} triangles, {2} materials): [{3}]",
-                    staticMeshSettings.numVertices.ToString(), staticMeshSettings.numTriangles.ToString(), staticMeshSettings.numMaterials.ToString(),
-                    status.ToString()));
+                throw new Exception($"Unable to create static mesh for export ({staticMeshSettings.numVertices.ToString()} vertices, {staticMeshSettings.numTriangles.ToString()} triangles, {staticMeshSettings.numMaterials.ToString()} materials): [{status.ToString()}]");
             }
 
             Marshal.FreeHGlobal(verticesBuffer);
@@ -82,7 +80,7 @@ namespace SteamAudio
 
             var status = API.iplStaticMeshLoad(scene.Get(), serializedObject.Get(), null, IntPtr.Zero, out mStaticMesh);
             if (status != Error.Success)
-                throw new Exception(string.Format("Unable to load static mesh ({0}). [{1}]", dataAsset.name, status));
+                throw new Exception($"Unable to load static mesh ({dataAsset.name}). [{status}]");
 
             serializedObject.Release();
         }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioBakedListener.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioBakedListener.cs
@@ -128,7 +128,7 @@ namespace SteamAudio
             tasks[0].name = gameObject.name;
             tasks[0].identifier = mIdentifier;
 #if UNITY_2020_3_OR_NEWER
-            tasks[0].probeBatches = (useAllProbeBatches) ? FindObjectsByType<SteamAudioProbeBatch>(FindObjectsSortMode.None) : probeBatches;
+            tasks[0].probeBatches = (useAllProbeBatches) ? FindObjectsByType<SteamAudioProbeBatch>() : probeBatches;
 #else
             tasks[0].probeBatches = (useAllProbeBatches) ? FindObjectsOfType<SteamAudioProbeBatch>() : probeBatches;
 #endif
@@ -149,26 +149,40 @@ namespace SteamAudio
             AssetDatabase.StartAssetEditing();
 #endif
 
-            var tasks = new BakedDataTask[bakedListeners.Length];
-
-            for (var i = 0; i < bakedListeners.Length; i++)
-            {
-                tasks[i].gameObject = bakedListeners[i].gameObject;
-                tasks[i].component = bakedListeners[i];
-                tasks[i].name = bakedListeners[i].gameObject.name;
-                tasks[i].identifier = bakedListeners[i].GetBakedDataIdentifier();
 #if UNITY_2020_3_OR_NEWER
-                tasks[i].probeBatches = (bakedListeners[i].useAllProbeBatches) ? FindObjectsByType<SteamAudioProbeBatch>(FindObjectsSortMode.None) : bakedListeners[i].probeBatches;
+            var allProbeBatches = FindObjectsByType<SteamAudioProbeBatch>();
 #else
-                tasks[i].probeBatches = (bakedListeners[i].useAllProbeBatches) ?  FindObjectsOfType<SteamAudioProbeBatch>() : bakedListeners[i].probeBatches;
+    var allProbeBatches = FindObjectsOfType<SteamAudioProbeBatch>();
 #endif
-                tasks[i].probeBatchNames = new string[tasks[i].probeBatches.Length];
-                tasks[i].probeBatchAssets = new SerializedData[tasks[i].probeBatches.Length];
-                for (var j = 0; j < tasks[i].probeBatchNames.Length; ++j)
+
+            var tasks = new BakedDataTask[bakedListeners.Length];
+            int bakedListenersLength = bakedListeners.Length;
+
+            for (var i = 0; i < bakedListenersLength; i++)
+            {
+                var listener = bakedListeners[i];
+
+                var task = new BakedDataTask();
+
+                task.gameObject = listener.gameObject;
+                task.component = listener;
+                task.name = listener.gameObject.name;
+                task.identifier = listener.GetBakedDataIdentifier();
+
+                task.probeBatches = (listener.useAllProbeBatches) ? allProbeBatches : listener.probeBatches;
+
+                int batchCount = task.probeBatches.Length;
+                task.probeBatchNames = new string[batchCount];
+                task.probeBatchAssets = new SerializedData[batchCount];
+
+                for (var j = 0; j < batchCount; ++j)
                 {
-                    tasks[i].probeBatchNames[j] = tasks[i].probeBatches[j].gameObject.name;
-                    tasks[i].probeBatchAssets[j] = tasks[i].probeBatches[j].GetAsset();
+                    var batch = task.probeBatches[j];
+                    task.probeBatchNames[j] = batch.gameObject.name;
+                    task.probeBatchAssets[j] = batch.GetAsset();
                 }
+
+                tasks[i] = task;
             }
 
 #if UNITY_EDITOR
@@ -186,7 +200,7 @@ namespace SteamAudio
         void CacheProbeBatchesUsed()
         {
 #if UNITY_2020_3_OR_NEWER
-            mProbeBatchesUsed = (useAllProbeBatches) ? FindObjectsByType<SteamAudioProbeBatch>(FindObjectsSortMode.None) : probeBatches;
+            mProbeBatchesUsed = (useAllProbeBatches) ? FindObjectsByType<SteamAudioProbeBatch>() : probeBatches;
 #else
             mProbeBatchesUsed = (useAllProbeBatches) ? FindObjectsOfType<SteamAudioProbeBatch>() : probeBatches;
 #endif

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioBakedSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioBakedSource.cs
@@ -128,7 +128,7 @@ namespace SteamAudio
             tasks[0].name = gameObject.name;
             tasks[0].identifier = mIdentifier;
 #if UNITY_2020_3_OR_NEWER
-            tasks[0].probeBatches = (useAllProbeBatches) ? FindObjectsByType<SteamAudioProbeBatch>(FindObjectsSortMode.None) : probeBatches;
+            tasks[0].probeBatches = (useAllProbeBatches) ? FindObjectsByType<SteamAudioProbeBatch>() : probeBatches;
 #else
             tasks[0].probeBatches = (useAllProbeBatches) ?  FindObjectsOfType<SteamAudioProbeBatch>() : probeBatches;
 #endif
@@ -149,26 +149,41 @@ namespace SteamAudio
             AssetDatabase.StartAssetEditing();
 #endif
 
-            var tasks = new BakedDataTask[bakedSources.Length];
-
-            for (var i = 0; i < bakedSources.Length; i++)
-            {
-                tasks[i].gameObject = bakedSources[i].gameObject;
-                tasks[i].component = bakedSources[i];
-                tasks[i].name = bakedSources[i].gameObject.name;
-                tasks[i].identifier = bakedSources[i].GetBakedDataIdentifier();
+            // Hoist the search out of the loop
 #if UNITY_2020_3_OR_NEWER
-                tasks[i].probeBatches = (bakedSources[i].useAllProbeBatches) ? FindObjectsByType<SteamAudioProbeBatch>(FindObjectsSortMode.None) : bakedSources[i].probeBatches;
+            var allProbeBatches = FindObjectsByType<SteamAudioProbeBatch>();
 #else
-                tasks[i].probeBatches = (bakedSources[i].useAllProbeBatches) ?  FindObjectsOfType<SteamAudioProbeBatch>() : bakedSources[i].probeBatches;
+    var allProbeBatches = FindObjectsOfType<SteamAudioProbeBatch>();
 #endif
-                tasks[i].probeBatchNames = new string[tasks[i].probeBatches.Length];
-                tasks[i].probeBatchAssets = new SerializedData[tasks[i].probeBatches.Length];
-                for (var j = 0; j < tasks[i].probeBatchNames.Length; ++j)
+
+            var tasks = new BakedDataTask[bakedSources.Length];
+            int count = bakedSources.Length;
+
+            for (var i = 0; i < count; i++)
+            {
+                var source = bakedSources[i];
+
+                var task = new BakedDataTask();
+
+                task.gameObject = source.gameObject;
+                task.component = source;
+                task.name = source.gameObject.name;
+                task.identifier = source.GetBakedDataIdentifier();
+
+                task.probeBatches = (source.useAllProbeBatches) ? allProbeBatches : source.probeBatches;
+
+                int batchCount = task.probeBatches.Length;
+                task.probeBatchNames = new string[batchCount];
+                task.probeBatchAssets = new SerializedData[batchCount];
+
+                for (var j = 0; j < batchCount; ++j)
                 {
-                    tasks[i].probeBatchNames[j] = tasks[i].probeBatches[j].gameObject.name;
-                    tasks[i].probeBatchAssets[j] = tasks[i].probeBatches[j].GetAsset();
+                    var batch = task.probeBatches[j];
+                    task.probeBatchNames[j] = batch.gameObject.name;
+                    task.probeBatchAssets[j] = batch.GetAsset();
                 }
+
+                tasks[i] = task;
             }
 
 #if UNITY_EDITOR
@@ -186,7 +201,7 @@ namespace SteamAudio
         void CacheProbeBatchesUsed()
         {
 #if UNITY_2020_3_OR_NEWER
-            mProbeBatchesUsed = (useAllProbeBatches) ? FindObjectsByType<SteamAudioProbeBatch>(FindObjectsSortMode.None) : probeBatches;
+            mProbeBatchesUsed = (useAllProbeBatches) ? FindObjectsByType<SteamAudioProbeBatch>() : probeBatches;
 #else
             mProbeBatchesUsed = (useAllProbeBatches) ? FindObjectsOfType<SteamAudioProbeBatch>() : probeBatches;
 #endif

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioListener.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioListener.cs
@@ -173,7 +173,7 @@ namespace SteamAudio
         }
 
         public void UpdateOutputs(SimulationFlags flags)
-        {}
+        { }
 
         private void OnDrawGizmosSelected()
         {
@@ -218,19 +218,25 @@ namespace SteamAudio
             CacheIdentifier();
             CacheProbeBatchesUsed();
 
-            var tasks = new BakedDataTask[1];
-            tasks[0].gameObject = gameObject;
-            tasks[0].component = this;
-            tasks[0].name = gameObject.name;
-            tasks[0].identifier = mIdentifier;
-            tasks[0].probeBatches = (useAllProbeBatches) ? FindObjectsOfType<SteamAudioProbeBatch>() : probeBatches;
-            tasks[0].probeBatchNames = new string[tasks[0].probeBatches.Length];
-            tasks[0].probeBatchAssets = new SerializedData[tasks[0].probeBatches.Length];
-            for (var i = 0; i < tasks[0].probeBatchNames.Length; ++i)
+            var task = new BakedDataTask();
+            task.gameObject = gameObject;
+            task.component = this;
+            task.name = gameObject.name;
+            task.identifier = mIdentifier;
+#if UNITY_2020_3_OR_NEWER
+            task.probeBatches = (useAllProbeBatches) ? FindObjectsByType<SteamAudioProbeBatch>() : probeBatches;
+#else
+            task.probeBatches = (useAllProbeBatches) ? FindObjectsOfType<SteamAudioProbeBatch>() : probeBatches;
+#endif
+            task.probeBatchNames = new string[task.probeBatches.Length];
+            task.probeBatchAssets = new SerializedData[task.probeBatches.Length];
+            for (var i = 0; i < task.probeBatchNames.Length; ++i)
             {
-                tasks[0].probeBatchNames[i] = tasks[0].probeBatches[i].gameObject.name;
-                tasks[0].probeBatchAssets[i] = tasks[0].probeBatches[i].GetAsset();
+                task.probeBatchNames[i] = task.probeBatches[i].gameObject.name;
+                task.probeBatchAssets[i] = task.probeBatches[i].GetAsset();
             }
+
+            var tasks = new BakedDataTask[1] { task };
 
             Baker.BeginBake(tasks);
         }
@@ -241,15 +247,20 @@ namespace SteamAudio
             AssetDatabase.StartAssetEditing();
 #endif
 
-            var tasks = new BakedDataTask[listeners.Length];
-
-            for (var i = 0; i < listeners.Length; i++)
+            int listenerCount = listeners.Length;
+            var tasks = new BakedDataTask[listenerCount];
+            for (var i = 0; i < listenerCount; i++)
             {
                 tasks[i].gameObject = listeners[i].gameObject;
                 tasks[i].component = listeners[i];
                 tasks[i].name = listeners[i].gameObject.name;
                 tasks[i].identifier = listeners[i].GetBakedDataIdentifier();
+
+#if UNITY_2022_3_OR_NEWER
+                tasks[i].probeBatches = (listeners[i].useAllProbeBatches) ? FindObjectsByType<SteamAudioProbeBatch>() : listeners[i].probeBatches;
+#else
                 tasks[i].probeBatches = (listeners[i].useAllProbeBatches) ? FindObjectsOfType<SteamAudioProbeBatch>() : listeners[i].probeBatches;
+#endif
                 tasks[i].probeBatchNames = new string[tasks[i].probeBatches.Length];
                 tasks[i].probeBatchAssets = new SerializedData[tasks[i].probeBatches.Length];
 
@@ -275,7 +286,11 @@ namespace SteamAudio
 
         void CacheProbeBatchesUsed()
         {
+#if UNITY_2022_3_OR_NEWER
+            mProbeBatchesUsed = (useAllProbeBatches) ? FindObjectsByType<SteamAudioProbeBatch>() : probeBatches;
+#else
             mProbeBatchesUsed = (useAllProbeBatches) ? FindObjectsOfType<SteamAudioProbeBatch>() : probeBatches;
+#endif
         }
 #endif
     }

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioManager.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioManager.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright 2017-2023 Valve Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -172,9 +172,6 @@ namespace SteamAudio
 
         public static SteamAudioListener GetSteamAudioListener()
         {
-            if (sSingleton.mListenerComponent == null)
-                return null;
-
             return sSingleton.mListenerComponent;
         }
 
@@ -930,11 +927,11 @@ namespace SteamAudio
             {
                 var scene = SceneManager.GetSceneAt(i);
 
-                EditorUtility.DisplayProgressBar("Steam Audio", string.Format("Exporting scene: {0}", scene.name), (float)i / (float)SceneManager.sceneCount);
+                EditorUtility.DisplayProgressBar("Steam Audio", $"Exporting scene: {scene.name}", (float)i / (float)SceneManager.sceneCount);
 
                 if (!scene.isLoaded)
                 {
-                    Debug.LogWarning(string.Format("Scene {0} is not loaded in the hierarchy.", scene.name));
+                    Debug.LogWarning($"Scene {scene.name} is not loaded in the hierarchy.");
                     continue;
                 }
 
@@ -952,7 +949,7 @@ namespace SteamAudio
             {
                 var scene = SceneManager.GetSceneByBuildIndex(i);
 
-                EditorUtility.DisplayProgressBar("Steam Audio", string.Format("Exporting scene: {0}", scene.name), (float)i / (float)SceneManager.sceneCountInBuildSettings);
+                EditorUtility.DisplayProgressBar("Steam Audio", $"Exporting scene: {scene.name}", (float)i / (float)SceneManager.sceneCountInBuildSettings);
 
                 var shouldClose = false;
                 if (!scene.isLoaded)
@@ -992,11 +989,11 @@ namespace SteamAudio
             {
                 var scene = SceneManager.GetSceneAt(i);
 
-                EditorUtility.DisplayProgressBar("Steam Audio", string.Format("Exporting dynamic objects in scene: {0}", scene.name), (float)i / (float)SceneManager.sceneCount);
+                EditorUtility.DisplayProgressBar("Steam Audio", $"Exporting dynamic objects in scene: {scene.name}", (float)i / (float)SceneManager.sceneCount);
 
                 if (!scene.isLoaded)
                 {
-                    Debug.LogWarning(string.Format("Scene {0} is not loaded in the hierarchy.", scene.name));
+                    Debug.LogWarning($"Scene {scene.name} is not loaded in the hierarchy.");
                     continue;
                 }
 
@@ -1014,7 +1011,7 @@ namespace SteamAudio
             {
                 var scene = SceneManager.GetSceneByBuildIndex(i);
 
-                EditorUtility.DisplayProgressBar("Steam Audio", string.Format("Exporting dynamic objects in scene: {0}", scene.name), (float)i / (float)SceneManager.sceneCountInBuildSettings);
+                EditorUtility.DisplayProgressBar("Steam Audio", $"Exporting dynamic objects in scene: {scene.name}", (float)i / (float)SceneManager.sceneCountInBuildSettings);
 
                 var shouldClose = false;
                 if (!scene.isLoaded)
@@ -1048,7 +1045,7 @@ namespace SteamAudio
             {
                 var scenePath = AssetDatabase.GUIDToAssetPath(sceneGUID);
 
-                EditorUtility.DisplayProgressBar("Steam Audio", string.Format("Exporting dynamic objects in scene: {0}", scenePath), (float)index / (float)numItems);
+                EditorUtility.DisplayProgressBar("Steam Audio", $"Exporting dynamic objects in scene: {scenePath}", (float)index / (float)numItems);
 
                 var activeScene = EditorSceneManager.GetActiveScene();
                 var isLoadedScene = (scenePath == activeScene.path);
@@ -1060,7 +1057,7 @@ namespace SteamAudio
                     var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssetPath(scenePath);
                     if (!(packageInfo == null || packageInfo.source == PackageSource.Embedded || packageInfo.source == PackageSource.Local))
                     {
-                        Debug.LogWarning(string.Format("Scene {0} is part of a read-only package, skipping.", scenePath));
+                        Debug.LogWarning($"Scene {scenePath} is part of a read-only package, skipping.");
                         continue;
                     }
 #endif
@@ -1082,7 +1079,7 @@ namespace SteamAudio
             {
                 var prefabPath = AssetDatabase.GUIDToAssetPath(prefabGUID);
 
-                EditorUtility.DisplayProgressBar("Steam Audio", string.Format("Exporting dynamic objects in prefab: {0}", prefabPath), (float)index / (float)numItems);
+                EditorUtility.DisplayProgressBar("Steam Audio", $"Exporting dynamic objects in prefab: {prefabPath}", (float)index / (float)numItems);
 
                 var prefab = AssetDatabase.LoadMainAssetAtPath(prefabPath) as GameObject;
                 var dynamicObjects = prefab.GetComponentsInChildren<SteamAudioDynamicObject>();
@@ -1099,7 +1096,7 @@ namespace SteamAudio
         public static void InstallFMODStudioPluginFiles()
         {
             // Make sure the FMOD Studio Unity integration is installed.
-            var assemblySuffix = ",FMODUnity";
+            const string assemblySuffix = ",FMODUnity";
             var FMODUnity_Settings = Type.GetType("FMODUnity.Settings" + assemblySuffix);
             if (FMODUnity_Settings == null)
             {
@@ -1141,7 +1138,7 @@ namespace SteamAudio
                     // We're using 2.2 or later, so we need to move files.
                     moveRequired = true;
 
-                    var moves = new Dictionary<string, string>();
+                    var moves = new Dictionary<string, string>(8);
                     moves.Add("Assets/Plugins/FMOD/lib/win/x86/phonon_fmod.dll", "Assets/Plugins/FMOD/platforms/win/lib/x86/phonon_fmod.dll");
                     moves.Add("Assets/Plugins/FMOD/lib/win/x86_64/phonon_fmod.dll", "Assets/Plugins/FMOD/platforms/win/lib/x86_64/phonon_fmod.dll");
                     moves.Add("Assets/Plugins/FMOD/lib/linux/x86/libphonon_fmod.so", "Assets/Plugins/FMOD/platforms/linux/lib/x86/libphonon_fmod.so");
@@ -1162,7 +1159,7 @@ namespace SteamAudio
                     // We're using 2.1 or earlier, so we need to move files.
                     moveRequired = true;
 
-                    var moves = new Dictionary<string, string>();
+                    var moves = new Dictionary<string, string>(8);
                     moves.Add("Assets/Plugins/FMOD/platforms/win/lib/x86/phonon_fmod.dll", "Assets/Plugins/FMOD/lib/win/x86/phonon_fmod.dll");
                     moves.Add("Assets/Plugins/FMOD/platforms/win/lib/x86_64/phonon_fmod.dll", "Assets/Plugins/FMOD/lib/win/x86_64/phonon_fmod.dll");
                     moves.Add("Assets/Plugins/FMOD/platforms/linux/lib/x86/libphonon_fmod.so", "Assets/Plugins/FMOD/lib/linux/x86/libphonon_fmod.so");
@@ -1231,7 +1228,7 @@ namespace SteamAudio
             var result = AssetDatabase.CreateFolder(parent, baseName);
             if (string.IsNullOrEmpty(result))
             {
-                Debug.LogErrorFormat("Unable to create asset directory {0} in {1}: {2}", baseName, parent, result);
+                Debug.LogErrorFormat($"Unable to create asset directory {baseName} in {parent}: {result}");
                 return false;
             }
 
@@ -1244,7 +1241,7 @@ namespace SteamAudio
             {
                 if (!AssetExists(source))
                 {
-                    Debug.LogErrorFormat("Unable to find plugin file: {0}", source);
+                    Debug.LogErrorFormat($"Unable to find plugin file: {source}");
                     return false;
                 }
 
@@ -1253,7 +1250,7 @@ namespace SteamAudio
 
                 if (!EnsureAssetDirectoryExists(directory))
                 {
-                    Debug.LogErrorFormat("Unable to create directory: {0}", directory);
+                    Debug.LogErrorFormat($"Unable to create directory: {directory}");
                     return false;
                 }
 
@@ -1261,11 +1258,11 @@ namespace SteamAudio
 
                 if (!string.IsNullOrEmpty(result))
                 {
-                    Debug.LogErrorFormat("Unable to move {0} to {1}: {2}", source, destination, result);
+                    Debug.LogErrorFormat($"Unable to move {source} to {destination}: {result}");
                     return false;
                 }
 
-                Debug.LogFormat("Moved {0} to {1}.", source, destination);
+                Debug.LogFormat($"Moved {source} to {destination}.");
             }
 
             return true;
@@ -1279,7 +1276,7 @@ namespace SteamAudio
 
             if (objects == null || objects.Length == 0)
             {
-                Debug.LogError(string.Format("Dynamic object {0} has no Steam Audio geometry attached. Skipping export.", dynamicObject.name));
+                Debug.LogError($"Dynamic object {dynamicObject.name} has no Steam Audio geometry attached. Skipping export.");
                 return;
             }
 
@@ -1289,7 +1286,7 @@ namespace SteamAudio
             if (!exportOBJ && dataAsset == null)
                 return;
 
-            if (exportOBJ && (objFileName == null || objFileName.Length == 0))
+            if (exportOBJ && (string.IsNullOrEmpty(objFileName)))
                 return;
 
             Export(objects, dynamicObject.name, dataAsset, objFileName, true, exportOBJ);
@@ -1431,10 +1428,7 @@ namespace SteamAudio
             var uniqueGameObjects = new HashSet<GameObject>(gameObjects);
 
             gameObjects.Clear();
-            foreach (var uniqueGameObject in uniqueGameObjects)
-            {
-                gameObjects.Add(uniqueGameObject);
-            }
+            gameObjects.AddRange(uniqueGameObjects);
 
             return gameObjects;
         }
@@ -1567,7 +1561,7 @@ namespace SteamAudio
 
             if (objects == null || objects.Length == 0)
             {
-                Debug.LogWarning(string.Format("Scene {0} has no Steam Audio static geometry. Skipping export.", unityScene.name));
+                Debug.LogWarning($"Scene {unityScene.name} has no Steam Audio static geometry. Skipping export.");
                 return;
             }
 
@@ -1577,7 +1571,7 @@ namespace SteamAudio
             if (!exportOBJ && dataAsset == null)
                 return;
 
-            if (exportOBJ && (objFileName == null || objFileName.Length == 0))
+            if (exportOBJ && (string.IsNullOrEmpty(objFileName)))
                 return;
 
             Export(objects, unityScene.name, dataAsset, objFileName, false, exportOBJ);
@@ -1596,7 +1590,7 @@ namespace SteamAudio
 
             if (vertices.Length == 0 || triangles.Length == 0 || materialIndices.Length == 0 || materials.Length == 0)
             {
-                Debug.LogError(string.Format("Steam Audio {0} [{1}]: No Steam Audio Geometry components attached.", type, name));
+                Debug.LogError($"Steam Audio {type} [{name}]: No Steam Audio Geometry components attached.");
                 return;
             }
 
@@ -1618,7 +1612,7 @@ namespace SteamAudio
                 staticMesh.Save(dataAsset);
             }
 
-            Debug.Log(string.Format("Steam Audio {0} [{1}]: Exported to {2}.", type, name, (exportOBJ) ? objFileName : dataAsset.name));
+            Debug.Log($"Steam Audio {type} [{name}]: Exported to {((exportOBJ) ? objFileName : dataAsset.name)}.");
 
             staticMesh.Release();
             scene.Release();
@@ -1755,7 +1749,9 @@ namespace SteamAudio
             var numTriangles = new int[gameObjects.Length];
             var totalNumVertices = 0;
             var totalNumTriangles = 0;
-            for (var i = 0; i < gameObjects.Length; ++i)
+
+            int objectCount = gameObjects.Length;
+            for (var i = 0; i < objectCount; ++i)
             {
                 numVertices[i] = GetNumVertices(gameObjects[i]);
                 numTriangles[i] = GetNumTriangles(gameObjects[i]);
@@ -1786,7 +1782,7 @@ namespace SteamAudio
 
             var verticesOffset = 0;
             var trianglesOffset = 0;
-            for (var i = 0; i < gameObjects.Length; ++i)
+            for (var i = 0; i < objectCount; ++i)
             {
                 GetVertices(gameObjects[i], vertices, verticesOffset, transform);
                 GetTriangles(gameObjects[i], triangles, trianglesOffset);
@@ -1948,9 +1944,13 @@ namespace SteamAudio
         {
             for (var i = startIndex; i < endIndex; ++i)
             {
-                triangles[i].index0 += indexOffset;
-                triangles[i].index1 += indexOffset;
-                triangles[i].index2 += indexOffset;
+                var tri = triangles[i];
+
+                tri.index0 += indexOffset;
+                tri.index1 += indexOffset;
+                tri.index2 += indexOffset;
+
+                triangles[i] = tri;
             }
         }
 

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioProbeBatch.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioProbeBatch.cs
@@ -149,7 +149,7 @@ namespace SteamAudio
 
             if (staticMeshComponent == null || staticMeshComponent.asset == null)
             {
-                Debug.LogError(string.Format("Scene {0} has not been exported. Click Steam Audio > Export Active Scene to do so.", SceneManager.GetActiveScene().name));
+                Debug.LogError($"Scene {SceneManager.GetActiveScene().name} has not been exported. Click Steam Audio > Export Active Scene to do so.");
                 return;
             }
 
@@ -279,7 +279,7 @@ namespace SteamAudio
             AddLayer(gameObject, identifier, dataSize);
         }
 
-        void UpdateGameObjectStatistics(BakedDataLayerInfo layerInfo)
+        static void UpdateGameObjectStatistics(BakedDataLayerInfo layerInfo)
         {
             if (layerInfo.identifier.type == BakedDataType.Reflections)
             {
@@ -300,7 +300,7 @@ namespace SteamAudio
             }
         }
 
-        BakedDataIdentifier GetBakedDataIdentifier()
+        public BakedDataIdentifier GetBakedDataIdentifier()
         {
             var identifier = new BakedDataIdentifier { };
             identifier.type = BakedDataType.Pathing;

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioReverbDataPoint.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioReverbDataPoint.cs
@@ -47,7 +47,7 @@ namespace SteamAudio
         static List<SteamAudioReverbData> sAssetsToFlush = null;
 
 #if STEAMAUDIO_ENABLED
-        void CreateFolderRecursively(string path)
+        static void CreateFolderRecursively(string path)
         {
 #if UNITY_EDITOR
             string[] parts = path.Split('/');

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioSource.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright 2017-2023 Valve Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -354,7 +354,7 @@ namespace SteamAudio
                 if (pathingProbeBatch == null)
                 {
                     pathing = false;
-                    Debug.LogWarningFormat("Pathing probe batch not set, disabling pathing for source {0}.", gameObject.name);
+                    Debug.LogWarningFormat($"Pathing probe batch not set, disabling pathing for source {gameObject.name}.");
                 }
                 else
                 {

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioStaticMesh.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/SteamAudioStaticMesh.cs
@@ -35,8 +35,7 @@ namespace SteamAudio
         {
             if (asset == null)
             {
-                Debug.LogWarningFormat("No asset set for Steam Audio Static Mesh in scene {0}. Export the scene before clicking Play.",
-                    gameObject.scene.name);
+                Debug.LogWarningFormat($"No asset set for Steam Audio Static Mesh in scene {gameObject.scene.name}. Export the scene before clicking Play.");
             }
 
             // Only load the static mesh asynchronously if we're using the default scene type. In particular, with

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/TrueAudioNextDevice.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/TrueAudioNextDevice.cs
@@ -32,7 +32,7 @@ namespace SteamAudio
 
             var status = API.iplTrueAudioNextDeviceCreate(openCLDevice.Get(), ref deviceSettings, out mTrueAudioNextDevice);
             if (status != Error.Success)
-                throw new Exception(string.Format("Unable to create TrueAudio Next device. [{0}]", status));
+                throw new Exception($"Unable to create TrueAudio Next device. [{status}]");
         }
 
         public TrueAudioNextDevice(TrueAudioNextDevice device)

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/UnityAudioEngineSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/UnityAudioEngineSource.cs
@@ -39,7 +39,7 @@ namespace SteamAudio
 
         public override void Destroy()
         {
-            var index = 28;
+            const int index = 28;
 
             if (mAudioSource != null)
             {

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/UnityAudioEngineState.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/UnityAudioEngineState.cs
@@ -63,7 +63,7 @@ namespace SteamAudio
         public override Transform GetListenerTransform()
         {
 #if UNITY_2023_3_OR_NEWER
-            var audioListener = GameObject.FindFirstObjectByType<AudioListener>();
+            var audioListener = GameObject.FindAnyObjectByType<AudioListener>();
 #else
             var audioListener = GameObject.FindObjectOfType<AudioListener>();
 #endif

--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Wwise/WwiseAudioEngineState.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Wwise/WwiseAudioEngineState.cs
@@ -56,7 +56,11 @@ namespace SteamAudio
     {
         public override Transform GetListenerTransform()
         {
+#if UNITY_2022_3_OR_NEWER
+            var wwiseListener = (MonoBehaviour) GameObject.FindAnyObjectByType<AkAudioListener>();
+#else
             var wwiseListener = (MonoBehaviour) GameObject.FindObjectOfType<AkAudioListener>();
+#endif
             if (wwiseListener == null)
                 return null;
 


### PR DESCRIPTION
Some non-breaking performance improvements. This also fixes the obsoleted code, which gave a warning in 6.4, and error in 6.5.

Performance fixes
- Change String.Format to Concatenation
- Remove FindObjectsSortMode.None, as this is depricated
- Make methods static where possible
- Use stromg.IsNullOrEmpty where possible
- Use local structs instead of array references for many references inside of a loop
- Cache FindObjectsByType outside of loops where possible
- Merge if-return to single return
- Use .AddRange

Big possible future improvements:
- Jobify and burst compile the most important pipeline
- Use the MeshDataAPI to read meshes

If there is interest in that, let me know as well