### PR TITLE
Fix Unreal reverb/reflections output-channel handling / Reverb buzzing

### DIFF
--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioReverb.cpp
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioReverb.cpp
@@ -32,6 +32,56 @@
 
 namespace SteamAudio {
 
+int32 GetAmbisonicsDecodeOutputChannelCount(int32 NumOutputChannels)
+{
+    switch (NumOutputChannels)
+    {
+    case 1:
+    case 2:
+    case 4:
+    case 6:
+    case 8:
+        return NumOutputChannels;
+    default:
+        // Steam Audio only has built-in speaker layouts for the standard channel
+        // counts above. Decode to stereo for unusual Unreal output layouts, then
+        // write it into the submix output buffer with the correct output stride.
+        return 2;
+    }
+}
+
+void InterleaveSteamAudioBufferToSubmixOutput(const IPLAudioBuffer& InBuffer, float* OutBufferData, int32 NumFrames, int32 NumOutputChannels)
+{
+    if (!OutBufferData || !InBuffer.data || NumFrames <= 0 || NumOutputChannels <= 0)
+    {
+        return;
+    }
+
+    const int32 NumFramesToCopy = FMath::Min(NumFrames, InBuffer.numSamples);
+
+    for (int32 FrameIndex = 0; FrameIndex < NumFramesToCopy; ++FrameIndex)
+    {
+        for (int32 Channel = 0; Channel < NumOutputChannels; ++Channel)
+        {
+            float Sample = 0.0f;
+            if (Channel < InBuffer.numChannels && InBuffer.data[Channel])
+            {
+                Sample = InBuffer.data[Channel][FrameIndex];
+            }
+
+            OutBufferData[FrameIndex * NumOutputChannels + Channel] = Sample;
+        }
+    }
+
+    for (int32 FrameIndex = NumFramesToCopy; FrameIndex < NumFrames; ++FrameIndex)
+    {
+        for (int32 Channel = 0; Channel < NumOutputChannels; ++Channel)
+        {
+            OutBufferData[FrameIndex * NumOutputChannels + Channel] = 0.0f;
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------------------------------------------------
 // FSteamAudioReverbSource
 // ---------------------------------------------------------------------------------------------------------------------
@@ -519,6 +569,7 @@ FSteamAudioReverbSubmixPlugin::FSteamAudioReverbSubmixPlugin()
     , PrevReflectionEffectType(IPL_REFLECTIONEFFECTTYPE_CONVOLUTION)
     , PrevDuration(0.0f)
     , PrevOrder(-1)
+    , PrevOutputChannels(0)
 {}
 
 FSteamAudioReverbSubmixPlugin::~FSteamAudioReverbSubmixPlugin()
@@ -537,8 +588,11 @@ void FSteamAudioReverbSubmixPlugin::SetReverbPlugin(SteamAudio::FSteamAudioRever
 	ReverbPlugin = Plugin;
 }
 
-void FSteamAudioReverbSubmixPlugin::LazyInit()
+void FSteamAudioReverbSubmixPlugin::LazyInit(int32 OutputChannels, bool bBinaural)
 {
+    OutputChannels = FMath::Max(OutputChannels, 1);
+    const int32 DecodeOutputChannels = bBinaural ? 2 : SteamAudio::GetAmbisonicsDecodeOutputChannelCount(OutputChannels);
+
     if (!Context)
     {
         Context = iplContextRetain(SteamAudio::FSteamAudioModule::GetManager().GetContext());
@@ -581,7 +635,7 @@ void FSteamAudioReverbSubmixPlugin::LazyInit()
         }
     }
 
-    if ((!AmbisonicsDecodeEffect || PrevOrder != SimulationSettings.maxOrder) && HRTF)
+    if ((!AmbisonicsDecodeEffect || PrevOrder != SimulationSettings.maxOrder || PrevOutputChannels != DecodeOutputChannels) && HRTF)
     {
         if (AmbisonicsDecodeEffect)
         {
@@ -589,7 +643,7 @@ void FSteamAudioReverbSubmixPlugin::LazyInit()
         }
 
         IPLAmbisonicsDecodeEffectSettings AmbisonicsDecodeSettings{};
-        AmbisonicsDecodeSettings.speakerLayout = SteamAudio::GetSpeakerLayoutForNumChannels(2);
+        AmbisonicsDecodeSettings.speakerLayout = SteamAudio::GetSpeakerLayoutForNumChannels(DecodeOutputChannels);
         AmbisonicsDecodeSettings.hrtf = HRTF;
         AmbisonicsDecodeSettings.maxOrder = SimulationSettings.maxOrder;
 
@@ -646,9 +700,14 @@ void FSteamAudioReverbSubmixPlugin::LazyInit()
         }
     }
 
-    if (!OutBuffer.data)
+    if (!OutBuffer.data || OutBuffer.numChannels != DecodeOutputChannels)
     {
-        IPLerror Status = iplAudioBufferAllocate(Context, 2, AudioSettings.frameSize, &OutBuffer);
+        if (OutBuffer.data)
+        {
+            iplAudioBufferFree(Context, &OutBuffer);
+        }
+
+        IPLerror Status = iplAudioBufferAllocate(Context, DecodeOutputChannels, AudioSettings.frameSize, &OutBuffer);
         if (Status != IPL_STATUS_SUCCESS)
         {
             UE_LOG(LogSteamAudio, Error, TEXT("Unable to create output buffer for reverb effect. [%d]"), Status);
@@ -658,6 +717,7 @@ void FSteamAudioReverbSubmixPlugin::LazyInit()
     PrevReflectionEffectType = SimulationSettings.reflectionType;
     PrevDuration = SimulationSettings.maxDuration;
     PrevOrder = SimulationSettings.maxOrder;
+    PrevOutputChannels = DecodeOutputChannels;
 }
 
 void FSteamAudioReverbSubmixPlugin::ShutDown()
@@ -762,7 +822,10 @@ void FSteamAudioReverbSubmixPlugin::OnProcessAudio(const FSoundEffectSubmixInput
 
     IPLSimulationSettings SimulationSettings = SteamAudio::FSteamAudioModule::GetManager().GetRealTimeSettings(static_cast<IPLSimulationFlags>(IPL_SIMULATIONFLAGS_REFLECTIONS | IPL_SIMULATIONFLAGS_PATHING));
 
-    LazyInit();
+    USteamAudioReverbSubmixPluginPreset* CurrentPreset = Cast<USteamAudioReverbSubmixPluginPreset>(GetPreset());
+    const bool bBinaural = (CurrentPreset && CurrentPreset->Settings.bApplyHRTF && !SteamAudio::FUnrealAudioEngineState::IsHRTFDisabled());
+
+    LazyInit(OutData.NumChannels, bBinaural);
 
     if (ReverbPlugin)
 	{
@@ -788,8 +851,7 @@ void FSteamAudioReverbSubmixPlugin::OnProcessAudio(const FSoundEffectSubmixInput
 		}
 
 		// If requested, apply reverb to the input.
-		USteamAudioReverbSubmixPluginPreset* ReverbPreset = Cast<USteamAudioReverbSubmixPluginPreset>(GetPreset());
-		if (ReverbPreset && ReverbPreset->Settings.bApplyReverb)
+		if (CurrentPreset && CurrentPreset->Settings.bApplyReverb)
 		{
             // If a Steam Audio Listener component has not set the current reverb source, stop.
             IPLSource CurrentReverbSource = GetReverbSource();
@@ -828,17 +890,15 @@ void FSteamAudioReverbSubmixPlugin::OnProcessAudio(const FSoundEffectSubmixInput
 
         if (bHasOutput && HRTF && AmbisonicsDecodeEffect && IndirectBuffer.data && OutBuffer.data)
         {
-            USteamAudioReverbSubmixPluginPreset* CurrentPreset = Cast<USteamAudioReverbSubmixPluginPreset>(GetPreset());
-
             IPLAmbisonicsDecodeEffectParams AmbisonicsDecodeParams{};
             AmbisonicsDecodeParams.order = SimulationSettings.maxOrder;
             AmbisonicsDecodeParams.hrtf = HRTF;
             AmbisonicsDecodeParams.orientation = SteamAudio::FSteamAudioModule::GetManager().GetListenerCoordinates();
-            AmbisonicsDecodeParams.binaural = (CurrentPreset && CurrentPreset->Settings.bApplyHRTF && !SteamAudio::FUnrealAudioEngineState::IsHRTFDisabled()) ? IPL_TRUE : IPL_FALSE;
+            AmbisonicsDecodeParams.binaural = bBinaural ? IPL_TRUE : IPL_FALSE;
 
             iplAmbisonicsDecodeEffectApply(AmbisonicsDecodeEffect, &AmbisonicsDecodeParams, &IndirectBuffer, &OutBuffer);
 
-            iplAudioBufferInterleave(Context, &OutBuffer, OutBufferData);
+            SteamAudio::InterleaveSteamAudioBufferToSubmixOutput(OutBuffer, OutBufferData, InData.NumFrames, OutData.NumChannels);
         }
 	}
 }

--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioReverb.h
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioReverb.h
@@ -236,6 +236,7 @@ private:
     IPLReflectionEffectType PrevReflectionEffectType;
     float PrevDuration;
     int PrevOrder;
+    int32 PrevOutputChannels;
 
 	/** Double-buffered reference to the Steam Audio simulation source. */
 	static IPLSource ReverbSource[2];
@@ -244,7 +245,7 @@ private:
 	static std::atomic<bool> bNewReverbSourceWritten;
 
 	/** Ensures that the Steam Audio effects are initialized. */
-	void LazyInit();
+	void LazyInit(int32 OutputChannels, bool bBinaural);
 
 	/** Destroys Steam Audio effects. */
 	void ShutDown();


### PR DESCRIPTION
## Summary

This fixes distorted/buzzing Steam Audio reflections in the Unreal plugin when Unreal's audio mixer output device has more channels than the Steam Audio reflection decode buffer.

The Unreal submix path previously decoded reflections to stereo in the binaural/HRTF case, then interleaved that stereo Steam Audio buffer directly into Unreal's submix output buffer. On multichannel output devices, Unreal's `OutData.AudioBuffer` is strided by the actual device channel count, not by the decoded Steam Audio channel count. With 4/6/8-channel output devices, this could write with the wrong stride and leave/corrupt channels, producing buzzing, hissing, or distorted reflections.

## What changed

- Track the previous reflection decode output channel count so the decode effect and output buffer are recreated when the device/decode layout changes.
- Keep binaural/HRTF reflections decoded to stereo, but copy them into Unreal's actual output buffer using `OutData.NumChannels` as the frame stride.
- For non-binaural reflections, decode to Steam Audio's matching built-in speaker layout for standard Unreal output channel counts:
  - mono: 1 channel
  - stereo: 2 channels
  - quad: 4 channels
  - 5.1: 6 channels
  - 7.1: 8 channels
- Fall back to stereo decode for unusual output channel counts while still writing with the correct Unreal output stride.
- Zero-fill any output channels that are not provided by the decoded Steam Audio buffer.

## Files changed

- `unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioReverb.cpp`
- `unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioReverb.h`

## Issues addressed

Likely fixes:

- Fixes https://github.com/ValveSoftware/steam-audio/issues/506
- Fixes https://github.com/ValveSoftware/steam-audio/issues/486

May also improve similar open Unreal reverb/reflection crackling reports, but these should be treated as speculative unless they are reproduced on non-stereo output devices:

- https://github.com/ValveSoftware/steam-audio/issues/230 — `[UE4.27] Reverb introduces massive crackling to sound`
- https://github.com/ValveSoftware/steam-audio/issues/410 — `[UE 5.3.2] Crackling sound`
- https://github.com/ValveSoftware/steam-audio/issues/386 — `UE5 reverb is non-functional and causes crackling`
- https://github.com/ValveSoftware/steam-audio/issues/420 — `Reverb Simulation is Broken UE5.5.4 (Steam Audio 4.6.1)`
- https://github.com/ValveSoftware/steam-audio/issues/374 — `Sound crackles`

## Validation performed

Validated with diagnostics on an effected Windows machine using an 8-channel virtual audio device (`SteelSeries Sonar - Gaming`).
