### PR TITLE
[Unity] Reduce Main Thread Cost by avoiding redundant AudioSource.SetSpatializerFloat() calls

### DIFF
--- a/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/UnityAudioEngineSource.cs
+++ b/unity/src/project/SteamAudioUnity/Assets/Plugins/SteamAudio/Scripts/Runtime/UnityAudioEngineSource.cs
@@ -30,6 +30,9 @@ namespace SteamAudio
         {
             mAudioSource = gameObject.GetComponent<AudioSource>();
 
+            for (int i = 0; i < mCachedParameters.Length; i++)
+                mCachedParameters[i] = float.NaN;
+
             mSteamAudioSource = gameObject.GetComponent<SteamAudioSource>();
             if (mSteamAudioSource)
             {
@@ -52,46 +55,58 @@ namespace SteamAudio
             }
         }
 
+        const int SPATIALIZER_PARAMETER_COUNT = 34;
+        readonly float[] mCachedParameters = new float[SPATIALIZER_PARAMETER_COUNT];
+
+        void SetParameter(int index, float value)
+        {
+            if (mCachedParameters[index] == value)
+                return;
+
+            mCachedParameters[index] = value;
+            mAudioSource.SetSpatializerFloat(index, value);
+        }
+
         public override void UpdateParameters(SteamAudioSource source)
         {
             if (!mAudioSource)
                 return;
 
             var index = 0;
-            mAudioSource.SetSpatializerFloat(index++, (source.distanceAttenuation) ? 1.0f : 0.0f);
-            mAudioSource.SetSpatializerFloat(index++, (source.airAbsorption) ? 1.0f : 0.0f);
-            mAudioSource.SetSpatializerFloat(index++, (source.directivity) ? 1.0f : 0.0f);
-            mAudioSource.SetSpatializerFloat(index++, (source.occlusion) ? 1.0f : 0.0f);
-            mAudioSource.SetSpatializerFloat(index++, (source.transmission) ? 1.0f : 0.0f);
-            mAudioSource.SetSpatializerFloat(index++, (source.reflections) ? 1.0f : 0.0f);
-            mAudioSource.SetSpatializerFloat(index++, (source.pathing) ? 1.0f : 0.0f);
-            mAudioSource.SetSpatializerFloat(index++, (float) source.interpolation);
-            mAudioSource.SetSpatializerFloat(index++, source.distanceAttenuationValue);
-            mAudioSource.SetSpatializerFloat(index++, (source.distanceAttenuationInput == DistanceAttenuationInput.CurveDriven) ? 1.0f : 0.0f);
-            mAudioSource.SetSpatializerFloat(index++, source.airAbsorptionLow);
-            mAudioSource.SetSpatializerFloat(index++, source.airAbsorptionMid);
-            mAudioSource.SetSpatializerFloat(index++, source.airAbsorptionHigh);
-            mAudioSource.SetSpatializerFloat(index++, (source.airAbsorptionInput == AirAbsorptionInput.UserDefined) ? 1.0f : 0.0f);
-            mAudioSource.SetSpatializerFloat(index++, source.directivityValue);
-            mAudioSource.SetSpatializerFloat(index++, source.dipoleWeight);
-            mAudioSource.SetSpatializerFloat(index++, source.dipolePower);
-            mAudioSource.SetSpatializerFloat(index++, (source.directivityInput == DirectivityInput.UserDefined) ? 1.0f : 0.0f);
-            mAudioSource.SetSpatializerFloat(index++, source.occlusionValue);
-            mAudioSource.SetSpatializerFloat(index++, (float) source.transmissionType);
-            mAudioSource.SetSpatializerFloat(index++, source.transmissionLow);
-            mAudioSource.SetSpatializerFloat(index++, source.transmissionMid);
-            mAudioSource.SetSpatializerFloat(index++, source.transmissionHigh);
-            mAudioSource.SetSpatializerFloat(index++, source.directMixLevel);
-            mAudioSource.SetSpatializerFloat(index++, (source.applyHRTFToReflections) ? 1.0f : 0.0f);
-            mAudioSource.SetSpatializerFloat(index++, source.reflectionsMixLevel);
-            mAudioSource.SetSpatializerFloat(index++, (source.applyHRTFToPathing) ? 1.0f : 0.0f);
-            mAudioSource.SetSpatializerFloat(index++, source.pathingMixLevel);
+            SetParameter(index++, (source.distanceAttenuation) ? 1.0f : 0.0f);
+            SetParameter(index++, (source.airAbsorption) ? 1.0f : 0.0f);
+            SetParameter(index++, (source.directivity) ? 1.0f : 0.0f);
+            SetParameter(index++, (source.occlusion) ? 1.0f : 0.0f);
+            SetParameter(index++, (source.transmission) ? 1.0f : 0.0f);
+            SetParameter(index++, (source.reflections) ? 1.0f : 0.0f);
+            SetParameter(index++, (source.pathing) ? 1.0f : 0.0f);
+            SetParameter(index++, (float) source.interpolation);
+            SetParameter(index++, source.distanceAttenuationValue);
+            SetParameter(index++, (source.distanceAttenuationInput == DistanceAttenuationInput.CurveDriven) ? 1.0f : 0.0f);
+            SetParameter(index++, source.airAbsorptionLow);
+            SetParameter(index++, source.airAbsorptionMid);
+            SetParameter(index++, source.airAbsorptionHigh);
+            SetParameter(index++, (source.airAbsorptionInput == AirAbsorptionInput.UserDefined) ? 1.0f : 0.0f);
+            SetParameter(index++, source.directivityValue);
+            SetParameter(index++, source.dipoleWeight);
+            SetParameter(index++, source.dipolePower);
+            SetParameter(index++, (source.directivityInput == DirectivityInput.UserDefined) ? 1.0f : 0.0f);
+            SetParameter(index++, source.occlusionValue);
+            SetParameter(index++, (float) source.transmissionType);
+            SetParameter(index++, source.transmissionLow);
+            SetParameter(index++, source.transmissionMid);
+            SetParameter(index++, source.transmissionHigh);
+            SetParameter(index++, source.directMixLevel);
+            SetParameter(index++, (source.applyHRTFToReflections) ? 1.0f : 0.0f);
+            SetParameter(index++, source.reflectionsMixLevel);
+            SetParameter(index++, (source.applyHRTFToPathing) ? 1.0f : 0.0f);
+            SetParameter(index++, source.pathingMixLevel);
             index++; // Skip 2 deprecated params.
             index++;
-            mAudioSource.SetSpatializerFloat(index++, (source.directBinaural) ? 1.0f : 0.0f);
-            mAudioSource.SetSpatializerFloat(index++, mHandle);
-            mAudioSource.SetSpatializerFloat(index++, (source.perspectiveCorrection) ? 1.0f : 0.0f);
-            mAudioSource.SetSpatializerFloat(index++, (source.normalizePathingEQ) ? 1.0f : 0.0f);
+            SetParameter(index++, (source.directBinaural) ? 1.0f : 0.0f);
+            SetParameter(index++, mHandle);
+            SetParameter(index++, (source.perspectiveCorrection) ? 1.0f : 0.0f);
+            SetParameter(index++, (source.normalizePathingEQ) ? 1.0f : 0.0f);
         }
     }
 }


### PR DESCRIPTION
This pull request reduces the main-thread cost of **Unity** spatializer parameter updates by caching the last values submitted to `AudioSource.SetSpatializerFloat()` and skipping redundant updates.

In a scene with 500 **SteamAudioSource** instances, `SteamAudioSource.Update()` time decreased from approximately 150–300 µs to ~50 µs, reducing per-source overhead from roughly 300-600 ns to ~100 ns at baseline. (9800X3D)

`UnityAudioEngineSource.UpdateParameters()` currently forwards every spatializer parameter to **Unity** every update, even when the value has not changed. Since `AudioSource.SetSpatializerFloat()` performs a managed-to-native call, these redundant updates add unnecessary overhead when many SteamAudioSource components are present.

This change introduces a small per-source cache (34 floats, ~136 bytes) that tracks the last submitted values. The cache is initialized with `float.NaN` so that `SteamAudioSource.Awake()` still submits every parameter, while subsequent updates only invoke the Unity backend when a parameter actually changes.

The change is localized to **UnityAudioEngineSource** and introduces no API or behavioral changes.

This partially mitigates #459 and #393. Remaining Unity overhead comes primarily from repeated transform access in `SteamAudioSource.SetInputs()` and per-component `Update()` dispatch, which could be addressed separately.

Before: 
<img width="1313" height="874" alt="image" src="https://github.com/user-attachments/assets/433002af-d193-49c9-aecd-f237aaa9cc3a" />

After:
<img width="1313" height="874" alt="Unity_gRGRZtE3Og" src="https://github.com/user-attachments/assets/368eb441-37da-4a8c-a09d-0cc1a4e4b510" />