### PR TITLE
[Unreal] Fix Steam Audio Reflections not working in Standalone Mode

### DIFF
--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioModule.cpp
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioModule.cpp
@@ -104,10 +104,9 @@ void FSteamAudioModule::StartupModule()
 #if WITH_EDITOR
     FEditorDelegates::PostPIEStarted.AddRaw(this, &FSteamAudioModule::OnPIEStarted);
     FEditorDelegates::EndPIE.AddRaw(this, &FSteamAudioModule::OnEndPIE);
-#else
+#endif
     FCoreDelegates::OnFEngineLoopInitComplete.AddRaw(this, &FSteamAudioModule::OnEngineLoopInitComplete);
     FCoreDelegates::OnEnginePreExit.AddRaw(this, &FSteamAudioModule::OnEnginePreExit);
-#endif
 
     UE_LOG(LogSteamAudio, Log, TEXT("Initialized module SteamAudio."));
 }

--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioModule.cpp
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioModule.cpp
@@ -105,8 +105,11 @@ void FSteamAudioModule::StartupModule()
     FEditorDelegates::PostPIEStarted.AddRaw(this, &FSteamAudioModule::OnPIEStarted);
     FEditorDelegates::EndPIE.AddRaw(this, &FSteamAudioModule::OnEndPIE);
 #endif
-    FCoreDelegates::OnFEngineLoopInitComplete.AddRaw(this, &FSteamAudioModule::OnEngineLoopInitComplete);
-    FCoreDelegates::OnEnginePreExit.AddRaw(this, &FSteamAudioModule::OnEnginePreExit);
+	if (IsRunningGame()) 
+	{
+		FCoreDelegates::OnFEngineLoopInitComplete.AddRaw(this, &FSteamAudioModule::OnEngineLoopInitComplete);
+    	FCoreDelegates::OnEnginePreExit.AddRaw(this, &FSteamAudioModule::OnEnginePreExit);
+	}
 
     UE_LOG(LogSteamAudio, Log, TEXT("Initialized module SteamAudio."));
 }


### PR DESCRIPTION
This fixes Steam Audio Reverb/Reflections not working when a game is launched in Standalone mode from the Editor. 

This happens because WITH_EDITOR macro is defined not only in PIE, but also in Standalone mode. 
But `PostPIEStarted` and `EndPIE` editor delegates aren't used in Standalone mode. 
As a result, `PIEInitCount` remains zero, preventing Steam Audio from processing reflections.

Now `OnFEngineLoopInitComplete` and `OnEnginePreExit` Core delegates are used to change `PIEInitCount` in Standalone mode.

Fixes #392 