### PR TITLE
[UNREAL] Fix compile error on UE 4.27

### DIFF
--- a/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioDynamicObjectComponent.cpp
+++ b/unreal/src/SteamAudioUnreal/Plugins/SteamAudio/Source/SteamAudio/Private/SteamAudioDynamicObjectComponent.cpp
@@ -21,7 +21,7 @@
 #include "SteamAudioScene.h"
 
 #if WITH_EDITOR
-#include "Subsystems/EditorAssetSubsystem.h"
+#include "ObjectTools.h"
 #endif
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -103,10 +103,10 @@ void USteamAudioDynamicObjectComponent::CleaupDynamicComponentAsset()
 {
     if (!Scene && Asset.IsValid() && bIsAssetActive)
     {
-        auto EditorAssetSubsystem = GEditor ? GEditor->GetEditorSubsystem<UEditorAssetSubsystem>() : nullptr;
-        if (EditorAssetSubsystem)
+        UObject* LoadedAsset = Asset.TryLoad();
+        if (LoadedAsset)
         {
-            EditorAssetSubsystem->DeleteAsset(Asset.GetAssetPathString());
+            ObjectTools::DeleteAssets({LoadedAsset}, false);
             bIsAssetActive = false;
         }
     }


### PR DESCRIPTION
This PR aims to fix #573 

The current version of the plugin uses `Subsystems/EditorAssetSubsystem.h` which doesn't exist in UE 4.27. This PR fixes that by using `ObjectTools.h` to delete the dynamic asset instead.